### PR TITLE
egg entry nesting refactor

### DIFF
--- a/app/views/collection_entries/_collection_entry.html.erb
+++ b/app/views/collection_entries/_collection_entry.html.erb
@@ -10,6 +10,7 @@
     <fieldset>
       <legend>Egg Entry #<%= ee.id %></legend>
       <p>date: <%= ee.created_at.strftime("%m/%d/%Y")%></p>
+      <p>time: <%= ee.created_at.strftime("%l:%M%P UTC") %></p>
       <p>chicken: <%= ee.chicken.name %></p><br/>
       <br/>
     </fieldset>

--- a/db/migrate/20250210194833_add_display_name_to_users.rb
+++ b/db/migrate/20250210194833_add_display_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddDisplayNameToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :display_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_23_011616) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_10_194833) do
   create_table "chickens", force: :cascade do |t|
     t.string "name"
     t.string "breed"
@@ -50,6 +50,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_23_011616) do
     t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "display_name"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 


### PR DESCRIPTION
- Removing explicit creation of an array of `egg_entries` in favor of utilizing the existing Active Record relationship between ce's and ee's

* This is a small change but trying to get in the habit with little changes before beginning my next major feature. 