### PR TITLE
reformatting egg_entry display

### DIFF
--- a/app/views/collection_entries/_form.html.erb
+++ b/app/views/collection_entries/_form.html.erb
@@ -11,8 +11,13 @@
     </div>
   <% end %>
 
-  <h5>User ID: </h5>
-  <input name="collection_entry[user_id]"/><br/><br/>
+  <h5>Who collected?</h5>
+  <select name="collection_entry[user_id][][display_name]">
+    <% User.all.each do |user| %>
+      <option value="<%= user.id %>"><%= user.display_name %></option>
+    <% end %>
+  </select>
+  <br/><br/>
 
   <div>
     <fieldset>


### PR DESCRIPTION
- switching from text input that accepted a user id # to a more user-friendly version, allowing the current user to select their own name under a "Who collected?" prompt
- user_id is assigned to the entry via the `value` attribute of the `option`