### PR TITLE
removing duplicate route line that caused deploy to fail

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,6 @@ Rails.application.routes.draw do
     end
   end
   get '/users/edit/me' => 'users#edit', as: :edit_user # find way to remove the id# @ end of url
-  get '/users/edit/me' => 'users#edit', as: :edit_user # find way to remove the id# @ end of url
   resources :users
   get '/signup' => 'users#new'
   post '/users' => 'users#create'


### PR DESCRIPTION
Render automatic deploy failed because of a duplicate route; probably an artifact from tonight's complex merge conflicts