### PR TITLE
replacing updated_at time & date with created_at 

### DIFF
--- a/app/controllers/collection_entries_controller.rb
+++ b/app/controllers/collection_entries_controller.rb
@@ -6,7 +6,7 @@ class CollectionEntriesController < ApplicationController
     collection_entries = Current.household
       .collection_entries
       .includes(egg_entries: :chicken)
-      .order("updated_at desc")
+      .order("created_at desc")
 
     @calendar, @pagy, @collection_entries = pagy_calendar(
       collection_entries,
@@ -22,7 +22,7 @@ class CollectionEntriesController < ApplicationController
   def today
     @collection_entries = Current.household.collection_entries.includes(egg_entries: :chicken)
     .where(created_at: Time.current.localtime.beginning_of_day..Time.current.localtime.end_of_day)
-    .order("updated_at desc")
+    .order("created_at desc")
   end
 
   # GET /collection_entries/1 or /collection_entries/1.json

--- a/app/views/collection_entries/_collection_entry.html.erb
+++ b/app/views/collection_entries/_collection_entry.html.erb
@@ -1,7 +1,7 @@
 <div id="<%= dom_id collection_entry %>" class="">
 
   <a href="/collection_entries/<%= collection_entry.id %>"><p class="text-xl font-bold hover:font-extrabold"><%= local_relative_time(collection_entry.created_at, 'weekday-or-date') %></p>
-  <p class="text-sm mb-5"><%= local_time(collection_entry.updated_at, '%l:%M%P') %></p></a>
+  <p class="text-sm mb-5"><%= local_time(collection_entry.created_at, '%l:%M%P') %></p></a>
 
   <% if Current.user.mode == "layer" %>
     <p class="mb-5">Collected by <%= collection_entry.user.display_name %></p>


### PR DESCRIPTION
I decided against allowing users to select 'time eggs were collected'.

I had begun working on the collection entry time selection branch but soon realized that because I've been using the default `created_at` and `updated_at` timestamps, this is more complicated than I realized.

This patch should replace any usage of `updated_at` in production. 