### PR TITLE
adjusting conditional in users#create to resolve error

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,8 +20,9 @@ class UsersController < ApplicationController
 
   def create
     user = User.new(user_params)
-    if params[:household].key?(:invite_token)
-      user.household = Household.find_by(invite_token: params[:household][:invite_token])
+    @household = Household.find_by(invite_token: params[:household_invite_token]) if params[:household_invite_token] 
+    if @household
+      user.household = @household
     else 
       user.build_household
     end


### PR DESCRIPTION
### The error:
- users couldn't sign up _unless_ they had a household invite token
- this was due to the phrasing of the `if` clause in `users#create` 

### The fix:
- within `#create`, I'm now defining `@household` first and _then_ basing the conditional off of the existence of an inviting household.
- This avoids Rails having to parse the household parameters (which won't even exist in the absence of an inviting household), so that a user who's starting a household from scratch can sign up.