### PR TITLE
Amanda/PATCH - Bug #B114 - user signup param issue

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,10 +20,8 @@ class UsersController < ApplicationController
 
   def create
     user = User.new(user_params)
-    if params[:household]
-      if params[:household].key?(:invite_token)
-        user.household = Household.find_by(invite_token: params[:household][:invite_token])
-      end
+    if params.dig(:household, :invite_token)
+      user.household = Household.find_by(invite_token: params[:household][:invite_token])
     else
       user.build_household
     end


### PR DESCRIPTION
### work on 🌿 `amanda/patch/b114-user-signup-param-issue`:
____________
###  🐛 **THE BUG:** 
- in prod: new users trying to sign up without a household invite received a `500` error
- - logs stated `undefined method '.key?' for nil`

- upon inspection in dev, the `if` clause in `user#create`'s conditional was the source of the error, ie:
`if params[:household].key?(:invite_token)`
 _____________
### ✅ **THE FIX:**
- added another layer of conditional so that first, the presence of `params[:household]` is verified. 
- Now, in the absence of a household invite token, the conditional skips ahead to the `else` clause. Users can now sign up for new accounts without household invite tokens, and they can invite additional users to their household.
_____________
### 🔜 **FUTURE CONSIDERATIONS:**
- I realize I probably could omit Lines 24 & 26 and just run the assignment of `user.household` without a 2nd level of verification, but I want to keep the code explicit for the time being, in case I run into any other bugs with the signup flow.