### PR TITLE
Amanda/PATCH - Bug #B113 - sample chicken bug

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,6 +23,7 @@ class UsersController < ApplicationController
     if params[:household]
       if params[:household].key?(:invite_token)
         user.household = Household.find_by(invite_token: params[:household][:invite_token])
+        user.skip_account_seed
       end
     else 
       user.build_household
@@ -52,7 +53,7 @@ class UsersController < ApplicationController
       params.require(:user)
         .permit(
           :display_name, :email_address, :password, :household_id, 
-          :password_confirmation, :mode
+          :password_confirmation, :mode, :skip_account_seed
         )
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,11 +20,9 @@ class UsersController < ApplicationController
 
   def create
     user = User.new(user_params)
-    if params[:household]
-      if params[:household].key?(:invite_token)
-        user.household = Household.find_by(invite_token: params[:household][:invite_token])
-        user.skip_account_seed
-      end
+    if params.dig(:household, :invite_token)
+      user.household = Household.find_by(invite_token: params[:household][:invite_token])
+      user.skip_account_seed
     else 
       user.build_household
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,8 +20,10 @@ class UsersController < ApplicationController
 
   def create
     user = User.new(user_params)
-    if params[:household].key?(:invite_token)
-      user.household = Household.find_by(invite_token: params[:household][:invite_token])
+    if params[:household]
+      if params[:household].key?(:invite_token)
+        user.household = Household.find_by(invite_token: params[:household][:invite_token])
+      end
     else 
       user.build_household
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,9 +4,13 @@ class User < ApplicationRecord
   belongs_to :household
   has_many :chickens
   has_many :collection_entries
-  after_create :seed_account
+  after_create :seed_account, unless: :household_invite_token?
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
+
+  def household_invite_token?
+    household.invite_token
+  end
 
   private
     def seed_account

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,13 +4,10 @@ class User < ApplicationRecord
   belongs_to :household
   has_many :chickens
   has_many :collection_entries
-  after_create :seed_account, unless: :household_invite_token?
+  attr_accessor :skip_account_seed
+  after_create :seed_account, unless: :skip_account_seed
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
-
-  def household_invite_token?
-    household.invite_token
-  end
 
   private
     def seed_account

--- a/app/views/collection_entries/_collection_entry.html.erb
+++ b/app/views/collection_entries/_collection_entry.html.erb
@@ -16,7 +16,7 @@
     <% collection_entry.egg_entries.each do |ee| %>
       <div id="<%= dom_id ee %>" class="justify-items-center mb-5">
         <p class="text-xl font-semibold"><%= ee.chicken.name %></p>
-        <%= image_tag('#{ee.chicken.image_url}", width: 200, 
+        <%= image_tag("#{ee.chicken.image_url}", width: 200, 
           class: 'rounded-2xl mb-5' ) %>
       </div>
     <% end %>

--- a/app/views/collection_entries/_collection_entry.html.erb
+++ b/app/views/collection_entries/_collection_entry.html.erb
@@ -16,7 +16,7 @@
     <% collection_entry.egg_entries.each do |ee| %>
       <div id="<%= dom_id ee %>" class="justify-items-center mb-5">
         <p class="text-xl font-semibold"><%= ee.chicken.name %></p>
-        <%= image_tag("#{ee.chicken.image_url}", width: 200, 
+        <%= image_tag('#{ee.chicken.image_url}", width: 200, 
           class: 'rounded-2xl mb-5' ) %>
       </div>
     <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -19,6 +19,7 @@
     <div>
       <% if @household %>
         <%= hidden_field_tag 'household[invite_token]', @household.invite_token %>
+        <%= hidden_field_tag 'user[skip_account_seed]' %>
       <% end %>
     </div>
 


### PR DESCRIPTION
### 🐜 **THE BUG:**
- **original intent of the `:seed_account` feature:** New accounts that are not linked to an existing household are populated with a sample chicken & sample collection entry. This allows the new user to see examples of both elements before creating their own.
- However, new users joining existing households get their accoutns seeded, as well, meaning these samples get tacked onto existing household data
  - This behavior is undesirable, since the household likely already has chickens and/or collection entries for the new user to see as examples. No need to add more noise.
__________________
### 🎯 **THE FIX:**
- [DEPRECATED]: conditionalizing the `after_create` action in `User` so that it only gets called for new users who don't have a household invite token.
- ✨ UPDATE ✨ 
  - adding a virtual attribute to `User`
  - when someone joins an existing household, the `skip_account_seed` attribute is passed as a param through a hidden field in the signup form; when this attribute is present, `User` bypasses the private `seed_account` method.
  - now, existing households don't get clogged up with extra collection entries and/or chickens anytime they add a new user!