### PR TITLE
Amanda/PATCH - Bug #B115 - sample chicken < > sample collection entry dependency issue

### DIFF
--- a/app/models/chicken.rb
+++ b/app/models/chicken.rb
@@ -1,5 +1,5 @@
 class Chicken < ApplicationRecord
-  has_many :egg_entries
+  has_many :egg_entries, dependent: :destroy
   belongs_to :household
 
   validates :name, :breed, presence: true

--- a/app/views/chickens/show.html.erb
+++ b/app/views/chickens/show.html.erb
@@ -13,7 +13,10 @@
       chickens_path, class: 'hover:font-bold' %>
     </div>
     <div class="py-3"><%= button_to "🗑️ Delete this chicken", 
-      @chicken, method: :delete, class: 'text-amber-700 hover:font-bold' %>
+      @chicken, method: :delete, class: 'text-amber-700 hover:font-bold', data: {
+        turbo_method: :delete, 
+        turbo_confirm: '⚠️ Are you sure? ⚠️ If you delete a chicken, all of their egg entries will be deleted, too.',
+      } %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### 🐌 **THE BUG:**
- When a user deletes one of their chickens, they cannot access `collection_entries#index` and in some cases, `collection_entries#today` (if the deleted chicken had entries for that day)
- Any collection entries that contain egg entries for that deleted chicken remain behind, and the egg entries' `chicken_id` fields are given a value of `nil`, which throws errors when the collection entry partials try to render
__________________
### 🎉 **THE FIX:**
- linked `Chicken` to `EggEntry` through `dependent: :destroy`
- added a `turbo_confirm` when user attempts to delete a chicken; the `turbo_confirm` informs them that they will lose all egg entries for that chicken if they delete
_______________________
### 🔜 **FUTURE CONSIDERATIONS:**
- I'd like to refactor this eventually to where the `turbo_confirm` is no longer necessary:
  - desired behavior of refactor: 
  - when a user deletes a chicken, a new id number is assigned to all of that chicken's `egg_entries` to avoid the assignment of `nil` -- this allows the user to keep all of the chicken's entries for their records.