### PR TITLE
Amanda/B116 - timestamp sorting bug 2: electric boogaloo

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,4 +15,8 @@ class ApplicationController < ActionController::Base
   def pagy_calendar_filter(collection, from, to)
     collection.where(created_at: from...to)
   end
+
+  def household_time
+    Time.current.in_time_zone(Current.household.time_zone)
+  end
 end

--- a/app/controllers/collection_entries_controller.rb
+++ b/app/controllers/collection_entries_controller.rb
@@ -20,10 +20,10 @@ class CollectionEntriesController < ApplicationController
   end
 
   def today
-    @collection_entries = Current.household.collection_entries.includes(egg_entries: :chicken)
-    .where(created_at: Time.current.localtime.beginning_of_day..Time.current.localtime.end_of_day)
-    .order("created_at desc")
     set_local_time_zone
+    @collection_entries = Current.household.collection_entries.includes(egg_entries: :chicken)
+    .where(created_at: household_time.beginning_of_day..household_time.end_of_day)
+    .order("created_at desc")
   end
 
   def show


### PR DESCRIPTION
### 🕷️ **the bug:** 
- after I deployed the changes made in #87 , I noticed that `collection_entries#today` was still using GMT for its own idea of 'today'
  - ie, at 7pm my time, `collection_entries#today` did away with any entries I had made today and wiped the slate clean, as though it were 'tomorrow'.
- I realized that this was happening because the timestamp range in `CollectionEntriesController#today` was not using local time, and was instead, simply using `Time.current` as its base, ie the current time in GMT.
- Apparently, in PR 87, I had unwittingly removed `localtime` from the method chains of the upper & lower range limits.

__________
### 🦖 **the fix:**
- Since these timestamps are `Time` objects, I knew I couldn't use `#in_time_zone` as I did with `TimeWithZone` and `DateTime` objects.
- Instead, I re-implemented the `localtime` method to translate them into the user's local time.