### PR TITLE
Amanda/patch/b117 reporting discrepancy

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
   def pagy_calendar_period(collection)
     starting = collection.minimum(:created_at) || Time.current
     ending   = collection.maximum(:created_at) || Time.current
-    [starting.in_time_zone(Current.user.household.time_zone), ending.in_time_zone(Current.user.household.time_zone)]
+    [starting.in_time_zone(@local_time_zone), ending.in_time_zone(@local_time_zone)]
   end
 
   # return the collection filtered by a time period

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,13 @@ class ApplicationController < ActionController::Base
     collection.where(created_at: from...to)
   end
 
+  private
+
   def household_time
     Time.current.in_time_zone(Current.household.time_zone)
+  end
+
+  def set_local_time_zone
+    @local_time_zone = Current.user.household.time_zone
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,10 +19,13 @@ class ApplicationController < ActionController::Base
   private
 
   def household_time
-    Time.current.in_time_zone(Current.household.time_zone)
+    Time.current
+        .in_time_zone(Current.household.time_zone)
   end
 
   def set_local_time_zone
-    @local_time_zone = Current.user.household.time_zone
+    @local_time_zone = Current.user
+                              .household
+                              .time_zone
   end
 end

--- a/app/controllers/collection_entries_controller.rb
+++ b/app/controllers/collection_entries_controller.rb
@@ -97,8 +97,4 @@ class CollectionEntriesController < ApplicationController
     @users = Current.household.users
     @chickens = Current.household.chickens.where(status: :layer)
   end
-
-  def set_local_time_zone
-    @local_time_zone = Current.user.household.time_zone
-  end
 end

--- a/app/controllers/collection_entries_controller.rb
+++ b/app/controllers/collection_entries_controller.rb
@@ -3,9 +3,9 @@ class CollectionEntriesController < ApplicationController
 
   def index
     collection_entries = Current.household
-      .collection_entries
-      .includes(egg_entries: :chicken)
-      .order("created_at desc")
+                                .collection_entries
+                                .includes(egg_entries: :chicken)
+                                .order("created_at desc")
 
     @calendar, @pagy, @collection_entries = pagy_calendar(
       collection_entries,
@@ -21,26 +21,33 @@ class CollectionEntriesController < ApplicationController
 
   def today
     set_local_time_zone
-    @collection_entries = Current.household.collection_entries.includes(egg_entries: :chicken)
-    .where(created_at: household_time.beginning_of_day..household_time.end_of_day)
-    .order("created_at desc")
+    @collection_entries = Current.household
+                                 .collection_entries.includes(egg_entries: :chicken)
+                                 .where(created_at: household_time.beginning_of_day..household_time.end_of_day)
+                                 .order("created_at desc")
   end
 
   def new
-    @collection_entry = Current.household.collection_entries.build
+    @collection_entry = Current.household
+                               .collection_entries
+                               .build
     @collection_entry.egg_entries.build
     setup_form_data
   end
 
   def edit
     setup_form_data
-    @collection_entry = Current.household.collection_entries.find(params[:id])
+    @collection_entry = Current.household
+                               .collection_entries
+                               .find(params[:id])
     @collection_entry.egg_entries = EggEntry.where(collection_entry_id: @collection_entry.id)
   end
 
   def create
     if Current.user.mode == "layer"
-      @collection_entry = Current.household.collection_entries.build(collection_entry_params)
+      @collection_entry = Current.household
+                                 .collection_entries
+                                 .build(collection_entry_params)
 
       if @collection_entry.save
         redirect_to today_path, notice: "Collection entry was successfully created."
@@ -49,7 +56,9 @@ class CollectionEntriesController < ApplicationController
         render :new, status: :unprocessable_entity
       end
     else
-      @collection_entry = Current.household.collection_entries.build(collection_entry_params)
+      @collection_entry = Current.household
+                                 .collection_entries
+                                 .build(collection_entry_params)
       @users = Current.household.users.all
 
       if @collection_entry.save
@@ -81,8 +90,8 @@ class CollectionEntriesController < ApplicationController
 
   def set_collection_entry
     @collection_entry = Current.household
-      .collection_entries
-      .find(params.expect(:id))
+                               .collection_entries
+                               .find(params.expect(:id))
   end
 
   def collection_entry_params
@@ -95,6 +104,8 @@ class CollectionEntriesController < ApplicationController
 
   def setup_form_data
     @users = Current.household.users
-    @chickens = Current.household.chickens.where(status: :layer)
+    @chickens = Current.household
+                       .chickens
+                       .where(status: :layer)
   end
 end

--- a/app/controllers/collection_entries_controller.rb
+++ b/app/controllers/collection_entries_controller.rb
@@ -78,26 +78,27 @@ class CollectionEntriesController < ApplicationController
   end
 
   private
-    def set_collection_entry
-      @collection_entry = Current.household
-        .collection_entries
-        .find(params.expect(:id))
-    end
 
-    def collection_entry_params
-      params.require(:collection_entry)
-        .permit(:user_id, egg_entries_attributes: [
-          :id, :egg_count, :chicken_id, :collection_entry_id, :_destroy,
-        ]
-      )
-    end
+  def set_collection_entry
+    @collection_entry = Current.household
+      .collection_entries
+      .find(params.expect(:id))
+  end
 
-    def setup_form_data
-      @users = Current.household.users
-      @chickens = Current.household.chickens.where(status: :layer)
-    end
+  def collection_entry_params
+    params.require(:collection_entry)
+      .permit(:user_id, egg_entries_attributes: [
+        :id, :egg_count, :chicken_id, :collection_entry_id, :_destroy,
+      ]
+    )
+  end
 
-    def set_local_time_zone
-      @local_time_zone = Current.user.household.time_zone
-    end
+  def setup_form_data
+    @users = Current.household.users
+    @chickens = Current.household.chickens.where(status: :layer)
+  end
+
+  def set_local_time_zone
+    @local_time_zone = Current.user.household.time_zone
+  end
 end

--- a/app/controllers/marketing_controller.rb
+++ b/app/controllers/marketing_controller.rb
@@ -3,9 +3,9 @@ class MarketingController < ApplicationController
   def home
     set_local_time_zone
     @collection_entries = Current.household
-      .collection_entries
-      .includes(egg_entries: :chicken)
-      .where(created_at: household_time.beginning_of_day..household_time.end_of_day)
+                                 .collection_entries
+                                 .includes(egg_entries: :chicken)
+                                 .where(created_at: household_time.beginning_of_day..household_time.end_of_day)
   end
 
   def how_it_works

--- a/app/controllers/marketing_controller.rb
+++ b/app/controllers/marketing_controller.rb
@@ -1,12 +1,11 @@
 class MarketingController < ApplicationController
   allow_unauthenticated_access only: [ :hello, :faq, :how_it_works, :acknowledgements ]
   def home
+    set_local_time_zone
     @collection_entries = Current.household
       .collection_entries
       .includes(egg_entries: :chicken)
-      .where(
-        created_at: Time.current.localtime.beginning_of_day..Time.current.localtime.end_of_day
-      )
+      .where(created_at: household_time.beginning_of_day..household_time.end_of_day)
   end
 
   def how_it_works
@@ -19,5 +18,11 @@ class MarketingController < ApplicationController
   end
 
   def hello
+  end
+
+  private
+
+  def set_local_time_zone
+    @local_time_zone = Current.user.household.time_zone
   end
 end

--- a/app/controllers/marketing_controller.rb
+++ b/app/controllers/marketing_controller.rb
@@ -19,10 +19,4 @@ class MarketingController < ApplicationController
 
   def hello
   end
-
-  private
-
-  def set_local_time_zone
-    @local_time_zone = Current.user.household.time_zone
-  end
 end


### PR DESCRIPTION
### 🐌 **THE BUG:**
- The post-login landing page (`Marketing#home`) does not reflect an accurate tally of the current day's collection entries.
- The 'Today's Entries' page does have the correct tally, so there's a reporting discrepancy
__________________
### 🎉 **THE FIX:**
- redefined `@collection_entries`' definition to match that of `CollectionEntriesController` per the changes made in #102 
- also did a little refactoring
  - pulled a shared method into `ApplicationController`, and then used it to abstract away time zone definitions within `ApplicationController`'s pagy calendar method 
 - FORMATTING:
   - adjusted indentation of private methods in `CollectionEntriesController`
   - adjusted longer daisychains of methods to multiline format for readability (in `CollectionEntriesController`, `MarketingController` & `ApplicationController`)
_______________________