### PR TITLE
Timepicker Feature Rollout Phase 3

### DIFF
--- a/app/controllers/collection_entries_controller.rb
+++ b/app/controllers/collection_entries_controller.rb
@@ -1,5 +1,6 @@
 class CollectionEntriesController < ApplicationController
   before_action :set_collection_entry, only: %i[ edit update destroy ]
+  before_action :set_local_time_zone
 
   def index
     collection_entries = Current.household
@@ -44,6 +45,10 @@ class CollectionEntriesController < ApplicationController
     if Current.user.mode == "layer"
       @collection_entry = Current.household.collection_entries.build(collection_entry_params)
 
+      if params[:collection_entry][:collected_at].present?
+        @collection_entry.collected_at = Time.zone.parse(params[:collection_entry][:collected_at])
+      end
+
       if @collection_entry.save
         redirect_to today_path, notice: "Collection entry was successfully created."
       else
@@ -53,6 +58,10 @@ class CollectionEntriesController < ApplicationController
     else
       @collection_entry = Current.household.collection_entries.build(collection_entry_params)
       @users = Current.household.users.all
+
+      if params[:collection_entry][:collected_at].present?
+        @collection_entry.collected_at = Time.zone.parse(params[:collection_entry][:collected_at])
+      end
 
       if @collection_entry.save
         redirect_to today_path,
@@ -108,5 +117,6 @@ class CollectionEntriesController < ApplicationController
 
     def set_local_time_zone
       @local_time_zone = Current.user.household.time_zone
+      Time.zone =  @local_time_zone
     end
 end

--- a/app/models/collection_entry.rb
+++ b/app/models/collection_entry.rb
@@ -3,4 +3,5 @@ class CollectionEntry < ApplicationRecord
   accepts_nested_attributes_for :egg_entries, allow_destroy: true
   belongs_to :household
   belongs_to :user
+  validates :collected_at, presence: true
 end

--- a/app/views/collection_entries/_collection_entry.html.erb
+++ b/app/views/collection_entries/_collection_entry.html.erb
@@ -1,10 +1,10 @@
 <div id="<%= dom_id collection_entry %>" class="">
 
   <p class="text-xl font-bold">
-    <%= collection_entry.created_at.in_time_zone(@local_time_zone).strftime("%A, %B %d") %>
+    <%= (collection_entry.collected_at || collection_entry.created_at).in_time_zone(@local_time_zone).strftime("%A, %B %d") %>
   </p>
   <p class="text-sm mb-5">
-    <%= collection_entry.created_at.in_time_zone(@local_time_zone).strftime("%l:%M%P") %>
+    <%= (collection_entry.collected_at || collection_entry.created_at).in_time_zone(@local_time_zone).strftime("%l:%M%P") %>
   </p>
 
   <% if Current.user.mode == "layer" %>

--- a/app/views/collection_entries/_form_container.html.erb
+++ b/app/views/collection_entries/_form_container.html.erb
@@ -19,6 +19,7 @@
             class: '' %>
       </div>
         <%= collection_entry_form.text_field :collected_at,
+            required: true,
             data: {
               controller: "flatpickr",
               flatpickr_enable_time: true,

--- a/app/views/collection_entries/_form_container.html.erb
+++ b/app/views/collection_entries/_form_container.html.erb
@@ -23,7 +23,10 @@
               controller: "flatpickr",
               flatpickr_enable_time: true,
               flatpickr_no_calendar: true,
-              flatpickr_date_format: "h:i K",
+              flatpickr_date_format: "Y-m-d h:i K",
+              flatpickr_alt_input: true,
+              flatpickr_alt_format: "h:i K",
+              flatpickr_default_date: Date.current,
               flatpickr_click_opens: true,
               flatpickr_default_hour: 8,
             } %>


### PR DESCRIPTION
## tl:dr;

Switching collection entry views to use `collected_at` with timezone handling and multi-layer validation.

- NOTE: "Phase 2" of this feature rollout was the backfill in prod

--------

## work on 🌿`amanda/switch-to-collected-at-display`

### > Timezone Handling
  - Set `Time.zone` to household timezone in controller
  - Parse submitted times in household timezone before saving to UTC
  - Configure Flatpickr with `altInput` to submit full datetime (date + time)
  - Users see time-only picker, but form submits complete datetime

### > View Updates
  - Switch collection entry display from `created_at` to `collected_at`
  - Add fallback: `(collected_at || created_at)` for safety
  - Times display correctly in household timezone

### > Validation Layers
  - Model-level: `validates :collected_at, presence: true`
  - Form-level: HTML `required` attribute on time field
  - View-level: Fallback to `created_at` if `collected_at` is `nil`

### > What This Enables
  - Users can now specify collection time (not just use current time)
  - Timepicker defaults to 8:00 AM for convenience

--------

## 📊 testing

  - verified no nil `collected_at` values existed in prod before deploy
  - all tests pass locally

--------

## 🔜 next steps/future considerations
- monitor prod after deploy
- next phase of feature rollout: add db-level validation to `collected_at`
- collect user feedback for potential UX/UI / CSS changes
