### PR TITLE
2026 Rebrand - Phase 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@
 
 # Running list of flagged issues, bugs, and TODOs (local working doc)
 /FLAGS.md
+
+# Code review notes (local working doc)
+/CODE_REVIEW.md

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@
 
 # Design plan (local working doc, not committed)
 /DESIGN_PLAN.md
+
+# Running list of flagged issues, bugs, and TODOs (local working doc)
+/FLAGS.md

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@
 
 # Work logs
 /work_log*.md
+
+# Design plan (local working doc, not committed)
+/DESIGN_PLAN.md

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,12 +1,173 @@
 @import "tailwindcss";
 @import "./pagy.css";
 
+/* ============================================================
+   Coop design tokens — palette + type stack for the redesign.
+   Exposed both as @theme (so utilities like bg-coop-cream work)
+   and as plain CSS vars (so component classes can compose them).
+   ============================================================ */
+@theme {
+	--color-coop-cream:        #fbf5e9;  /* page background */
+	--color-coop-bg-alt:       #f4ead4;  /* alt panel / inactive button bg */
+	--color-coop-surface:      #ffffff;  /* cards */
+	--color-coop-line:         #e6d8b8;  /* hairline borders, dividers */
+	--color-coop-ink:          #2d1f10;  /* primary text */
+	--color-coop-ink-soft:     #6e5a3e;  /* secondary text, kickers */
+	--color-coop-primary:      #c4622d;  /* terracotta — buttons, accents, headlines */
+	--color-coop-primary-soft: #f4d4b8;  /* tinted bg for active nav, soft fills */
+	--color-coop-accent:       #7a8c4a;  /* olive — secondary accent (rare) */
+	--color-coop-warn:         #d4a548;  /* mustard — warnings */
+	--color-coop-danger:       #a13c2c;  /* deep red — destructive */
+
+	/* Status pill foreground/background — keyed by lifecycle value */
+	--color-coop-pullet-bg:   #f5e9c8;
+	--color-coop-pullet-fg:   #7a5a18;
+	--color-coop-layer-bg:    #e2d2a4;
+	--color-coop-layer-fg:    #5a4515;
+	--color-coop-molting-bg:  #f0c79a;
+	--color-coop-molting-fg:  #7a3f15;
+	--color-coop-retired-bg:  #d8c8df;
+	--color-coop-retired-fg:  #4a2f5a;
+	--color-coop-expired-bg:  #d8d4cc;
+	--color-coop-expired-fg:  #5a544c;
+
+	/* Type stack */
+	--font-display: "Caprasimo", "Fraunces", Georgia, serif;
+	--font-body:    "Nunito", "Inter", system-ui, sans-serif;
+	--font-mono:    "JetBrains Mono", ui-monospace, monospace;
+}
+
+/* ============================================================
+   Component patterns. Use these when a piece reappears across
+   multiple views; otherwise prefer raw Tailwind utilities. The
+   prototypes use 18px card radii — Tailwind's nearest is rounded-2xl
+   (16px); we expose .coop-card so we don't fight the framework.
+   ============================================================ */
 @layer components {
+	/* Surface card — white with a hairline border on cream. */
+	.coop-card {
+		background-color: var(--color-coop-surface);
+		border: 1px solid var(--color-coop-line);
+		border-radius: 18px;
+	}
+
+	/* Primary button — filled terracotta. */
+	.coop-button-primary {
+		background-color: var(--color-coop-primary);
+		color: var(--color-coop-cream);
+		border: 1px solid var(--color-coop-primary);
+		border-radius: 12px;
+		padding: 12px 22px;
+		font-family: var(--font-body);
+		font-weight: 700;
+		font-size: 13px;
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		transition: filter 120ms ease;
+	}
+	.coop-button-primary:hover { filter: brightness(0.94); }
+
+	/* Secondary button — outlined, cream-on-ink. */
+	.coop-button-secondary {
+		background-color: transparent;
+		color: var(--color-coop-ink-soft);
+		border: 1px solid var(--color-coop-line);
+		border-radius: 12px;
+		padding: 12px 18px;
+		font-family: var(--font-body);
+		font-weight: 700;
+		font-size: 13px;
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		transition: background-color 120ms ease;
+	}
+	.coop-button-secondary:hover { background-color: var(--color-coop-bg-alt); }
+
+	/* Field shell — used by the redesigned chicken/collection forms. */
+	.coop-input {
+		background-color: var(--color-coop-bg-alt);
+		border: 1px solid var(--color-coop-line);
+		border-radius: 12px;
+		padding: 10px 14px;
+		font-family: var(--font-body);
+		font-size: 15px;
+		font-weight: 600;
+		color: var(--color-coop-ink);
+		width: 100%;
+	}
+	.coop-input:focus {
+		outline: none;
+		border-color: var(--color-coop-primary);
+	}
+
+	/* Pill — for hen selectors, tags, etc. */
+	.coop-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 4px 10px;
+		border-radius: 999px;
+		border: 1px solid var(--color-coop-line);
+		background-color: var(--color-coop-bg-alt);
+		font-family: var(--font-body);
+		font-weight: 600;
+		font-size: 12px;
+		color: var(--color-coop-ink);
+	}
+
+	/* Uppercase mono kicker — used above section titles, stats, fields. */
+	.coop-kicker {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		font-weight: 400;
+		letter-spacing: 0.18em;
+		text-transform: uppercase;
+		color: var(--color-coop-ink-soft);
+	}
+
+	/* Status pill — keyed by data-status so views just stamp the value.
+	   Usage: <span class="coop-status" data-status="layer">🐔 Layer</span>
+	   Falls back to a neutral chrome if data-status is missing or unknown. */
+	.coop-status {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 5px 12px;
+		border-radius: 999px;
+		font-family: var(--font-body);
+		font-size: 12px;
+		font-weight: 600;
+		background-color: var(--color-coop-bg-alt);
+		color: var(--color-coop-ink);
+	}
+	.coop-status[data-status="pullet"]  { background-color: var(--color-coop-pullet-bg);  color: var(--color-coop-pullet-fg); }
+	.coop-status[data-status="layer"]   { background-color: var(--color-coop-layer-bg);   color: var(--color-coop-layer-fg); }
+	.coop-status[data-status="molting"] { background-color: var(--color-coop-molting-bg); color: var(--color-coop-molting-fg); }
+	.coop-status[data-status="retired"] { background-color: var(--color-coop-retired-bg); color: var(--color-coop-retired-fg); }
+	.coop-status[data-status="expired"] { background-color: var(--color-coop-expired-bg); color: var(--color-coop-expired-fg); }
+
+	/* Page-level chrome that survives from the old design. */
+	.page-title {
+		font-weight: 900;
+		font-size: 2rem;
+		padding-bottom: 20px;
+		text-transform: uppercase;
+	}
+
+	/* ----------------------------------------------------------
+	   Deferred cleanup — these classes still drive
+	   collection_entries/index.html.erb (the old All Entries page).
+	   That view is being replaced in Phase 4 (full graphical calendar).
+	   When Phase 4 lands, delete this block. Until then they keep
+	   the legacy page rendering.
+	   ---------------------------------------------------------- */
 	.outer-container {
 		display: flex;
 		flex-direction: column;
 		justify-self: center;
-		gap: 20;
+		gap: 20px;
 	}
 
 	.collection-entries-container {
@@ -15,7 +176,7 @@
 		justify-items: center;
 		justify-self: center;
 		width: 100%;
-		gap: 20;
+		gap: 20px;
 
 		@media screen and (min-width: 900px) {
 			width: 600px;
@@ -26,7 +187,7 @@
 		background-color: var(--color-blue-100);
 		justify-self: center;
 		justify-items: center;
-		border-radius: 25;
+		border-radius: 25px;
 		padding-right: 20px;
 		padding-left: 20px;
 		padding-top: 5px;
@@ -36,53 +197,19 @@
 		background-color: var(--color-amber-50);
 		border-width: thin;
 		border-color: var(--color-amber-100);
-		border-radius: 15;
+		border-radius: 15px;
 		justify-self: center;
 		justify-items: center;
-		padding: 5;
-		margin-bottom: 10;
-	}
-
-	.card {
-		display: flex;
-		flex-direction: column;
-		background-color: var(--color-blue-200);
-		padding: 20px;
-		border-style: solid;
-		border-width: thin;
-		border-color: var(--color-blue-300);
-		border-radius: 25;
-	}
-
-	.page-title {
-		font-weight: 900;
-		font-size: 2rem; 
-		padding-bottom: 20px;
-		text-transform: uppercase;
-	}
-
-	.link {
-		color: var(--color-blue-600);
-		justify-self: center;
-		font-weight: 600;
-	}
-
-	.link:hover {
-		color: var(--color-blue-800);
+		padding: 5px;
+		margin-bottom: 10px;
 	}
 
 	.btn-upcase {
 		color: white;
 		font-size: medium;
 		font-weight: 600;
-		border-radius: 15;
-		padding: 7;
-		padding-left: 10;
-		padding-right: 10;
+		border-radius: 15px;
+		padding: 7px 10px;
 		margin: auto;
-	}
-
-	.btn-uppercase {
-
 	}
 }

--- a/app/controllers/collection_entries_controller.rb
+++ b/app/controllers/collection_entries_controller.rb
@@ -21,8 +21,14 @@ class CollectionEntriesController < ApplicationController
 
   def today
     set_local_time_zone
+    @viewing_date = parse_viewing_date(params[:date]) || household_time.to_date
+    @is_today = @viewing_date == household_time.to_date
+
+    day_start = @viewing_date.in_time_zone(@local_time_zone).beginning_of_day
+    day_end = day_start.end_of_day
+
     @collection_entries = Current.household.collection_entries.includes(:user, egg_entries: :chicken)
-    .where(created_at: household_time.beginning_of_day..household_time.end_of_day)
+    .where(created_at: day_start..day_end)
     .order("created_at desc")
 
     @todays_egg_total = @collection_entries.sum { |entry| entry.egg_entries.sum(&:egg_count) }
@@ -108,5 +114,15 @@ class CollectionEntriesController < ApplicationController
 
     def set_local_time_zone
       @local_time_zone = Current.user.household.time_zone
+    end
+
+    # Parses a YYYY-MM-DD param into a Date. Returns nil for blank or
+    # malformed input so the caller can fall back to "today" rather than
+    # 500ing on a bad query string.
+    def parse_viewing_date(raw)
+      return nil if raw.blank?
+      Date.iso8601(raw.to_s)
+    rescue ArgumentError, TypeError
+      nil
     end
 end

--- a/app/models/chicken.rb
+++ b/app/models/chicken.rb
@@ -10,6 +10,60 @@ class Chicken < ApplicationRecord
     expired: "expired"
   }, validate: { allow_nil: true }
 
+  # Per-breed accent palette. The first match (case-insensitive) on `breed`
+  # stamps `accent_color` (and `accent_secondary` for patterned breeds) onto
+  # the chicken at save time. Used across the app for avatars, leaderboard
+  # rows, calendar chips, and inline name links.
+  BREED_TINTS = [
+    { name: "Rhode Island Red",     tint: "#a8462a" },
+    { name: "Rhode Island White",   tint: "#f4ede0" },
+    { name: "ISA Brown",            tint: "#c2784a" },
+    { name: "Cinnamon Queen",       tint: "#b66536" },
+    { name: "Buff Orpington",       tint: "#d4a558" },
+    { name: "Black Orpington",      tint: "#2a2520" },
+    { name: "Lavender Orpington",   tint: "#bdb6c4" },
+    { name: "Barred Rock",          tint: "#5a5550", secondary: "#e6e2d8" },
+    { name: "Plymouth Rock",        tint: "#5a5550", secondary: "#e6e2d8" },
+    { name: "Black Australorp",     tint: "#1f1c18" },
+    { name: "Black Copper Maran",   tint: "#3a2a20" },
+    { name: "Cuckoo Maran",         tint: "#6b6660", secondary: "#d8d4ca" },
+    { name: "Wyandotte (Silver Laced)", tint: "#e8e3d6", secondary: "#2a2520" },
+    { name: "Wyandotte (Gold Laced)",   tint: "#b88542", secondary: "#2a2520" },
+    { name: "Speckled Sussex",      tint: "#7a4a2c", secondary: "#f0e8d8" },
+    { name: "Light Sussex",         tint: "#f4ede0", secondary: "#2a2520" },
+    { name: "Leghorn (White)",      tint: "#fbf6ec" },
+    { name: "Leghorn (Brown)",      tint: "#a8783a" },
+    { name: "Ameraucana",           tint: "#7a8a78" },
+    { name: "Easter Egger",         tint: "#9a8870" },
+    { name: "Olive Egger",          tint: "#6f7a4a" },
+    { name: "Welsummer",            tint: "#8a4f2a" },
+    { name: "New Hampshire Red",    tint: "#b25530" },
+    { name: "Silkie (White)",       tint: "#fbf6ec" },
+    { name: "Silkie (Black)",       tint: "#1f1c18" },
+    { name: "Silkie (Buff)",        tint: "#d4a558" },
+    { name: "Brahma (Light)",       tint: "#f4ede0", secondary: "#2a2520" },
+    { name: "Brahma (Dark)",        tint: "#5a5048", secondary: "#e6e2d8" },
+    { name: "Brahma (Buff)",        tint: "#d4a558" },
+    { name: "Faverolles (Salmon)",  tint: "#e8c4a0" },
+    { name: "Polish (White Crested Black)", tint: "#1f1c18", secondary: "#fbf6ec" },
+    { name: "Dominique",            tint: "#6b6660", secondary: "#d8d4ca" },
+    { name: "Delaware",             tint: "#f4ede0", secondary: "#2a2520" },
+    { name: "Jersey Giant (Black)", tint: "#1a1814" },
+    { name: "Buckeye",              tint: "#9a4528" },
+    { name: "Chantecler",           tint: "#fbf6ec" }
+  ].freeze
+
+  # Curated palette offered when a user selects "Custom breed" in the New
+  # Chicken form. The thirteenth swatch in that picker is a free-pick
+  # rainbow (rendered in the view), so this list is intentionally 12 wide.
+  CUSTOM_PALETTE = %w[
+    #a8462a #d4a558 #8a4f2a #3a2a20 #1f1c18
+    #fbf6ec #bfb098 #7a8a78 #6f7a4a #bdb6c4
+    #c2784a #e8c4a0
+  ].freeze
+
+  before_validation :backfill_accent_from_breed
+
   validates :name, :breed, presence: true
   validates :dob, presence: { message: '(date of birth) can\'t be blank' }
 
@@ -27,4 +81,17 @@ class Chicken < ApplicationRecord
     status: 'layer',
     image_url: 'https://tinyurl.com/pt9b974e',
   ).tap { |record| record.readonly! }
+
+  private
+
+  def backfill_accent_from_breed
+    return if accent_color.present?
+    return if breed.blank?
+
+    match = BREED_TINTS.find { |b| b[:name].casecmp?(breed.to_s.strip) }
+    return unless match
+
+    self.accent_color = match[:tint]
+    self.accent_secondary = match[:secondary] if match[:secondary]
+  end
 end

--- a/app/models/chicken.rb
+++ b/app/models/chicken.rb
@@ -24,6 +24,7 @@ class Chicken < ApplicationRecord
     { name: "Lavender Orpington",   tint: "#bdb6c4" },
     { name: "Barred Rock",          tint: "#5a5550", secondary: "#e6e2d8" },
     { name: "Plymouth Rock",        tint: "#5a5550", secondary: "#e6e2d8" },
+    { name: "Production Blue",      tint: "#7a7a85" },
     { name: "Black Australorp",     tint: "#1f1c18" },
     { name: "Black Copper Maran",   tint: "#3a2a20" },
     { name: "Cuckoo Maran",         tint: "#6b6660", secondary: "#d8d4ca" },

--- a/app/models/chicken.rb
+++ b/app/models/chicken.rb
@@ -2,6 +2,14 @@ class Chicken < ApplicationRecord
   has_many :egg_entries, dependent: :destroy
   belongs_to :household
 
+  enum :status, {
+    pullet: "pullet",
+    layer: "layer",
+    molting: "molting",
+    retired: "retired",
+    expired: "expired"
+  }, validate: { allow_nil: true }
+
   validates :name, :breed, presence: true
   validates :dob, presence: { message: '(date of birth) can\'t be blank' }
 
@@ -11,12 +19,12 @@ class Chicken < ApplicationRecord
   }
 
   NULL_CHICKEN = new(
-    id: nil, 
-    name: '[flock mode]', 
-    breed: 'ghost', 
-    tell: 'not really a chicken', 
-    dob: Time.now, 
-    status: 'layer', 
+    id: nil,
+    name: '[flock mode]',
+    breed: 'ghost',
+    tell: 'not really a chicken',
+    dob: Time.now,
+    status: 'layer',
     image_url: 'https://tinyurl.com/pt9b974e',
-  ).tap { |record | record.readonly! }
+  ).tap { |record| record.readonly! }
 end

--- a/app/models/household.rb
+++ b/app/models/household.rb
@@ -1,9 +1,10 @@
 class Household < ApplicationRecord
-  has_secure_token :invite_token 
+  has_secure_token :invite_token
   has_many :users
   has_many :chickens
   has_many :collection_entries
-  
+  has_many :egg_entries, through: :collection_entries
+
   def to_param
     invite_token
   end

--- a/app/queries/dashboard_stats.rb
+++ b/app/queries/dashboard_stats.rb
@@ -7,12 +7,19 @@
 # these become hot, wrap the call site in a Rails fragment cache keyed on
 # `[household, "dashboard", max(updated_at across egg_entries today)]`.
 #
-# Note on `created_at` vs `collected_at`: existing `EggEntry` records use
-# `created_at` for "when did the chicken lay this egg" because
-# `collection_entries.collected_at` was added recently and isn't yet
-# back-propagated to per-egg timestamps. This class uses `created_at` to
-# stay consistent with the existing `#today` action; revisit once the
-# data backfill catches up.
+# Timestamp semantics:
+#
+# All time-window filters use `collection_entries.created_at` — the parent
+# CollectionEntry's timestamp, NOT the per-egg `egg_entries.created_at`.
+# This matches the existing `#today` controller action and keeps stats
+# internally consistent (e.g., today_count and today_collections_count
+# always describe the same set of CEs). Per-egg timestamps can drift from
+# their parent when entries are edited or eggs are added via nested
+# attributes after the original CE was saved.
+#
+# Once `collection_entries.collected_at` is back-propagated to per-egg
+# timestamps, this class should switch all filters to `collected_at`. See
+# FLAGS.md "🐛 #today action filters by created_at, not collected_at".
 class DashboardStats
   def initialize(household, now: nil)
     @household = household
@@ -163,8 +170,12 @@ class DashboardStats
     egg_entries_in(today_range)
   end
 
+  # Filters egg_entries by their parent CollectionEntry's created_at.
+  # `@household.egg_entries` already joins through collection_entries
+  # (via `has_many :egg_entries, through: :collection_entries`), so this
+  # adds a where-clause on the joined table.
   def egg_entries_in(range)
-    @household.egg_entries.where(egg_entries: { created_at: range })
+    @household.egg_entries.where(collection_entries: { created_at: range })
   end
 
   def active_hens_scope
@@ -172,11 +183,14 @@ class DashboardStats
   end
 
   # Returns { "YYYY-MM-DD" => egg_count } for a time range, computing the
-  # date from the household-local TZ. We pull egg_entries with their
-  # created_at and group in Ruby — SQL DATE() functions vary across
-  # SQLite/Postgres and we want predictable TZ behavior either way.
+  # date from the household-local TZ.
+  #
+  # Plucks the *parent CollectionEntry*'s created_at to stay consistent
+  # with the rest of the class (see the timestamp-semantics note at the
+  # top). We group in Ruby rather than SQL because SQL DATE() functions
+  # vary across SQLite/Postgres and we want predictable TZ behavior.
   def daily_counts_for(range)
-    rows = egg_entries_in(range).pluck(:created_at, :egg_count)
+    rows = egg_entries_in(range).pluck("collection_entries.created_at", :egg_count)
     out = {}
     rows.each do |timestamp, count|
       key = timestamp.in_time_zone(household_time_zone).to_date.iso8601

--- a/app/queries/dashboard_stats.rb
+++ b/app/queries/dashboard_stats.rb
@@ -1,0 +1,187 @@
+# Aggregations consumed by the redesigned dashboard. Scoped per household;
+# all date math is done in the household's local time zone, not UTC or
+# server time.
+#
+# Methods return plain hashes / arrays / scalars so callers don't take an
+# implicit dependency on ActiveRecord scopes. No caching in v1; if any of
+# these become hot, wrap the call site in a Rails fragment cache keyed on
+# `[household, "dashboard", max(updated_at across egg_entries today)]`.
+#
+# Note on `created_at` vs `collected_at`: existing `EggEntry` records use
+# `created_at` for "when did the chicken lay this egg" because
+# `collection_entries.collected_at` was added recently and isn't yet
+# back-propagated to per-egg timestamps. This class uses `created_at` to
+# stay consistent with the existing `#today` action; revisit once the
+# data backfill catches up.
+class DashboardStats
+  def initialize(household, now: nil)
+    @household = household
+    @now = (now || Time.current).in_time_zone(household_time_zone)
+  end
+
+  # ---- Today ----
+
+  def today_count
+    today_egg_entries.sum(:egg_count)
+  end
+
+  def today_collections_count
+    @household.collection_entries.where(created_at: today_range).count
+  end
+
+  # ---- This week (Monday-Sunday in household TZ) ----
+
+  def this_week_count
+    egg_entries_in(this_week_range).sum(:egg_count)
+  end
+
+  # Percent change vs last week (same Mon-Sun window, shifted -7 days).
+  # Returns nil when last week had zero eggs (avoid divide-by-zero and
+  # the meaningless +∞ that would result).
+  def this_week_change_pct
+    last = egg_entries_in(last_week_range).sum(:egg_count)
+    return nil if last.zero?
+    (((this_week_count - last) / last.to_f) * 100).round
+  end
+
+  # 7 daily totals, oldest first, for the current week. Used by the
+  # sparkline component.
+  def this_week_sparkline_data
+    daily_counts_for(this_week_range)
+  end
+
+  # ---- Flock ----
+
+  # Excludes retired and expired birds; includes pullets, layers, molters.
+  def active_hens_count
+    active_hens_scope.count
+  end
+
+  # e.g. "1 molting · 1 retired" — just the non-default statuses worth
+  # surfacing under the "Active hens" stat. Returns "" when nothing
+  # interesting to say.
+  def active_hens_breakdown
+    bits = []
+    molting = @household.chickens.where(status: "molting").count
+    retired = @household.chickens.where(status: "retired").count
+    bits << "#{molting} molting" if molting.positive?
+    bits << "#{retired} retired" if retired.positive?
+    bits.join(" · ")
+  end
+
+  # Returns { chicken: <Chicken>, egg_count: <Integer> } for the top hen
+  # by egg count this calendar month. Nil if no eggs logged this month.
+  def best_in_flock_this_month
+    top = egg_entries_in(this_month_range)
+      .where.not(chicken_id: nil)
+      .group(:chicken_id)
+      .sum(:egg_count)
+      .max_by { |_, count| count }
+    return nil unless top
+
+    chicken_id, count = top
+    chicken = @household.chickens.find_by(id: chicken_id)
+    return nil unless chicken
+
+    { chicken: chicken, egg_count: count }
+  end
+
+  # Top 4 chickens by this-month egg count. Each entry:
+  # { chicken: <Chicken>, egg_count: <Integer>, rank: <Integer> }.
+  # Excludes chickens with zero eggs this month.
+  def employee_of_the_month(limit: 4)
+    counts = egg_entries_in(this_month_range)
+      .where.not(chicken_id: nil)
+      .group(:chicken_id)
+      .sum(:egg_count)
+
+    return [] if counts.empty?
+
+    chickens_by_id = @household.chickens.where(id: counts.keys).index_by(&:id)
+
+    counts
+      .sort_by { |_, count| -count }
+      .first(limit)
+      .each_with_index
+      .filter_map do |(chicken_id, count), i|
+        chicken = chickens_by_id[chicken_id]
+        next unless chicken
+        { chicken: chicken, egg_count: count, rank: i + 1 }
+      end
+  end
+
+  # ---- Calendar ----
+
+  # { "YYYY-MM-DD" => egg_count } for the requested month, household-local.
+  # Days with zero eggs are omitted; the calendar component treats missing
+  # keys as empty.
+  def month_calendar_data(year:, month:)
+    range = month_range(year, month)
+    daily_counts_for(range)
+  end
+
+  # ---- Today's collections strip ----
+
+  # Today's CollectionEntry records ordered most-recent first, with
+  # eager-loaded egg_entries + users so the view renders without N+1.
+  def todays_collections
+    @household.collection_entries
+      .includes(:user, egg_entries: :chicken)
+      .where(created_at: today_range)
+      .order(created_at: :desc)
+  end
+
+  private
+
+  def household_time_zone
+    @household.time_zone.presence || Time.zone.name
+  end
+
+  def today_range
+    @now.beginning_of_day..@now.end_of_day
+  end
+
+  def this_week_range
+    @now.beginning_of_week..@now.end_of_week
+  end
+
+  def last_week_range
+    week_ago = @now - 1.week
+    week_ago.beginning_of_week..week_ago.end_of_week
+  end
+
+  def this_month_range
+    @now.beginning_of_month..@now.end_of_month
+  end
+
+  def month_range(year, month)
+    first = Time.zone.local(year, month, 1).in_time_zone(household_time_zone)
+    first.beginning_of_month..first.end_of_month
+  end
+
+  def today_egg_entries
+    egg_entries_in(today_range)
+  end
+
+  def egg_entries_in(range)
+    @household.egg_entries.where(egg_entries: { created_at: range })
+  end
+
+  def active_hens_scope
+    @household.chickens.where(status: %w[pullet layer molting])
+  end
+
+  # Returns { "YYYY-MM-DD" => egg_count } for a time range, computing the
+  # date from the household-local TZ. We pull egg_entries with their
+  # created_at and group in Ruby — SQL DATE() functions vary across
+  # SQLite/Postgres and we want predictable TZ behavior either way.
+  def daily_counts_for(range)
+    rows = egg_entries_in(range).pluck(:created_at, :egg_count)
+    out = {}
+    rows.each do |timestamp, count|
+      key = timestamp.in_time_zone(household_time_zone).to_date.iso8601
+      out[key] = (out[key] || 0) + count
+    end
+    out
+  end
+end

--- a/app/views/collection_entries/_collection_entry.html.erb
+++ b/app/views/collection_entries/_collection_entry.html.erb
@@ -1,48 +1,82 @@
-<div id="<%= dom_id collection_entry %>" class="">
-
-  <p class="text-xl font-bold">
-    <%= collection_entry.created_at.in_time_zone(@local_time_zone).strftime("%A, %B %d") %>
-  </p>
-  <p class="text-sm mb-5">
-    <%= collection_entry.created_at.in_time_zone(@local_time_zone).strftime("%l:%M%P") %>
-  </p>
-
-  <% if Current.user.mode == "layer" %>
-    <p class="mb-5 text-xl font-semibold"><%= collection_entry.user.display_name %> collected 
-    <%= pluralize(collection_entry.egg_entries.sum(:egg_count), 'egg') %>.</p>
-
-    <% collection_entry.egg_entries.each do |ee| %>
-      <div id="<%= dom_id ee %>" class="justify-items-center mb-5">
-        <%= link_to "#{ee.chicken.name}", ee.chicken, class: 'text-lg font-semibold' %>
-        <%= image_tag("#{ee.chicken.image_url}", width: 200, 
-          class: 'rounded-2xl mb-5' ) %>
-      </div>
-    <% end %>
-<% else %>
-  <p class="font-semibold mb-5">
-    <%= collection_entry.user.display_name %> collected 
-    <%= pluralize(collection_entry.egg_entries.sum(:egg_count), 'egg') %>.
-  </p>
-<% end %>
-
-<% if collection_entry.notes %>
-  <div class="flex flex-col justify-self-center items-center w-1/2">
-    <p>- - - - - - - - - - - - - - - - -</p>
-    <p class="font-bold text-2xl mb-2">Notes</p>
-    <div class="bg-blue-50 p-3 rounded-2xl mb-5">  
-      <%= collection_entry.notes %>
+<div id="<%= dom_id collection_entry %>">
+  <div style="display: flex;
+              justify-content: space-between;
+              align-items: baseline;
+              gap: 12px;
+              margin-bottom: 14px;">
+    <div>
+      <p style="font-family: var(--font-display);
+                font-size: 20px;
+                line-height: 1.15;
+                color: var(--color-coop-ink);
+                margin: 0;">
+        <%= collection_entry.created_at.in_time_zone(@local_time_zone).strftime("%A, %B %d") %>
+      </p>
+      <p class="coop-kicker" style="margin-top: 4px;">
+        <%= collection_entry.created_at.in_time_zone(@local_time_zone).strftime("%-l:%M %P") %>
+      </p>
     </div>
   </div>
-<% end %>
-</div>
-<div class="inline-flex gap-5 justify-center text-sm mt-5">
-  <%= link_to "✏️ edit entry", 
-    edit_collection_entry_path(collection_entry),
-    class:'bg-blue-100 hover:bg-blue-300 rounded-2xl p-2' %>
-  <%= button_to '🗙 delete entry', 
-    collection_entry,
-    method: :delete,
-    class: 'bg-blue-50 hover:bg-red-100 rounded-2xl p-2 hover:cursor-pointer',
-    form: { data: { turbo_confirm: 'Are you sure you want to delete this entry?' } } 
-  %>
+
+  <% if Current.user.mode == "layer" %>
+    <p style="font-family: var(--font-body);
+              font-size: 15px;
+              line-height: 1.5;
+              color: var(--color-coop-ink);
+              margin-bottom: 12px;">
+      <strong><%= collection_entry.user.display_name %></strong> collected
+      <strong><%= pluralize(collection_entry.egg_entries.sum(:egg_count), 'egg') %></strong>.
+    </p>
+
+    <% if collection_entry.egg_entries.any? %>
+      <ul class="flex flex-wrap gap-2" style="list-style: none; padding: 0; margin-bottom: 14px;">
+        <% collection_entry.egg_entries.each do |ee| %>
+          <li id="<%= dom_id ee %>">
+            <%= link_to ee.chicken.name, ee.chicken,
+                  class: "coop-pill",
+                  style: "text-decoration: none;" %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  <% else %>
+    <p style="font-family: var(--font-body);
+              font-size: 15px;
+              line-height: 1.5;
+              color: var(--color-coop-ink);
+              margin-bottom: 12px;">
+      <strong><%= collection_entry.user.display_name %></strong> collected
+      <strong><%= pluralize(collection_entry.egg_entries.sum(:egg_count), 'egg') %></strong>.
+    </p>
+  <% end %>
+
+  <% if collection_entry.notes.present? %>
+    <div style="margin-top: 12px;
+                padding-top: 12px;
+                border-top: 1px dashed var(--color-coop-line);">
+      <div class="coop-kicker" style="margin-bottom: 6px;">Notes</div>
+      <p style="font-family: var(--font-body);
+                font-size: 14px;
+                line-height: 1.5;
+                color: var(--color-coop-ink);
+                white-space: pre-wrap;
+                margin: 0;">
+        <%= collection_entry.notes %>
+      </p>
+    </div>
+  <% end %>
+
+  <div class="flex flex-wrap gap-2"
+       style="margin-top: 18px;
+              padding-top: 14px;
+              border-top: 1px solid var(--color-coop-line);">
+    <%= link_to "Edit", edit_collection_entry_path(collection_entry),
+          class: "coop-button-secondary",
+          style: "padding: 6px 14px; font-size: 12px; text-decoration: none;" %>
+    <%= button_to "Delete", collection_entry,
+          method: :delete,
+          class: "coop-button-secondary",
+          style: "padding: 6px 14px; font-size: 12px; color: var(--color-coop-danger); border-color: var(--color-coop-danger);",
+          form: { data: { turbo_confirm: "Are you sure you want to delete this entry?" } } %>
+  </div>
 </div>

--- a/app/views/collection_entries/_new_ce_button.html.erb
+++ b/app/views/collection_entries/_new_ce_button.html.erb
@@ -1,2 +1,3 @@
-<%= link_to "got some eggs?", new_collection_entry_path,
-  class: 'p-5 mb-8 bg-amber-600 text-white font-bold rounded-2xl' %>
+<%= link_to "Got some eggs?", new_collection_entry_path,
+      class: "coop-button-primary",
+      style: "text-decoration: none;" %>

--- a/app/views/collection_entries/today.html.erb
+++ b/app/views/collection_entries/today.html.erb
@@ -1,23 +1,43 @@
 <% content_for :title, @is_today ? "Today's Entries" : "Entries for #{@viewing_date.strftime('%b %-d, %Y')}" %>
 
-<div class="bg-blue-100 md:shrink-0 w-100 md:w-150 items-center
-  justify-self-center p-5 rounded-2xl mb-8">
-  <h2 class="font-bold text-lime-700 text-2xl pb-2">
-    <%= @is_today ? "Today's Count:" : "#{@viewing_date.strftime('%A, %b %-d')} Count:" %>
-  </h2>
-  <p class="text-xl font-semibold">
-    <%= pluralize(@todays_egg_total, 'egg') %>
-  </p>
-</div>
-<div class="my-10">
-  <%= render "new_ce_button" %>
-</div>
-<div id="collection_entries" 
-  class="md:shrink-0 w-100 md:w-150 items-center justify-self-center">
-  <% @collection_entries.each do |collection_entry| %>
-    <div class="flex flex-col mb-5 py-6 border border-blue-300 
-      rounded-2xl bg-blue-200">
-      <%= render collection_entry %>
+<div class="mx-auto" style="max-width: 720px;">
+  <%# Header: title + date kicker. %>
+  <div style="margin-bottom: 18px;">
+    <div class="coop-kicker" style="margin-bottom: 6px;">
+      <%= @is_today ? "Today" : @viewing_date.strftime("%A, %b %-d") %>
     </div>
-  <% end %>
+    <h1 style="font-family: var(--font-display);
+               font-size: clamp(32px, 6vw, 44px);
+               line-height: 1.05;
+               color: var(--color-coop-ink);
+               letter-spacing: -0.02em;">
+      <%= pluralize(@todays_egg_total, 'egg') %> collected.
+    </h1>
+  </div>
+
+  <%# Got some eggs? button. %>
+  <div style="margin-bottom: 24px;">
+    <%= render "new_ce_button" %>
+  </div>
+
+  <%# Entry list. %>
+  <div id="collection_entries" class="flex flex-col gap-4">
+    <% if @collection_entries.any? %>
+      <% @collection_entries.each do |collection_entry| %>
+        <div class="coop-card" style="padding: 22px 24px;">
+          <%= render collection_entry %>
+        </div>
+      <% end %>
+    <% else %>
+      <div class="coop-card"
+           style="padding: 28px 24px;
+                  text-align: center;
+                  color: var(--color-coop-ink-soft);
+                  font-style: italic;
+                  font-family: var(--font-body);
+                  font-size: 14px;">
+        No entries for <%= @is_today ? "today" : @viewing_date.strftime("%A, %b %-d") %> yet.
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/collection_entries/today.html.erb
+++ b/app/views/collection_entries/today.html.erb
@@ -1,9 +1,9 @@
-<% content_for :title, "Today's Entries" %>
+<% content_for :title, @is_today ? "Today's Entries" : "Entries for #{@viewing_date.strftime('%b %-d, %Y')}" %>
 
-<div class="bg-blue-100 md:shrink-0 w-100 md:w-150 items-center 
+<div class="bg-blue-100 md:shrink-0 w-100 md:w-150 items-center
   justify-self-center p-5 rounded-2xl mb-8">
   <h2 class="font-bold text-lime-700 text-2xl pb-2">
-    Today's Count:
+    <%= @is_today ? "Today's Count:" : "#{@viewing_date.strftime('%A, %b %-d')} Count:" %>
   </h2>
   <p class="text-xl font-semibold">
     <%= pluralize(@todays_egg_total, 'egg') %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
+    <meta name="theme-color" content="#c4622d">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -12,86 +13,61 @@
 
     <link rel="icon" href="/favicon.png" type="image/png">
     <link rel="apple-touch-icon" href="/favicon_lg.png">
+    <link rel="manifest" href="<%= pwa_manifest_path(format: :json) %>">
+
+    <%# Coop type stack — Caprasimo display, Nunito body, JetBrains Mono. %>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Caprasimo&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
 
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="bg-blue-50 text-blue-950 flex flex-col min-h-screen">
-    <header class="p-4 pb-6 text-center bg-blue-100">
-      <h1 class="text-5xl font-extrabold text-blue-400 hover:text-amber-600">
-        <%= link_to "🐔 Henventory 🥚", Current.user ? landing_path : root_path %>
-      </h1>
-    </header> 
+  <body class="flex flex-col min-h-screen"
+        style="background-color: var(--color-coop-cream);
+               color: var(--color-coop-ink);
+               font-family: var(--font-body);">
+    <%= render "shared/top_bar" %>
 
-    <section>
-      <nav class="flex justify-center bg-blue-200 ">
-        <ul class="flex w:full items-center justify-center text-center">
-          <% if Current.user %>
-            <li class="p-4 font-semibold hover:text-blue-400">
-              <%= link_to "📅 Today's Entries", today_path %>
-            </li>
-            <li class="p-4 font-semibold hover:text-blue-400">
-              <%= link_to "📒 All Entries", collection_entries_path %>
-            </li>
-            <% if Current.user.mode == "layer" %>
-              <li class="p-4 font-semibold hover:text-blue-400">
-                <%= link_to "🐔 My Flock", chickens_path %>
-              </li>
-            <% end %>
-            <li class="p-4 font-semibold hover:text-blue-400">
-              <%= link_to "⚙️ Settings", settings_path %>
-            </li>
-            <li class="p-4 font-semibold hover:text-red-700">
-              <%= button_to "👋 Log out", session_path, method: :delete %>
-            </li>
-          <% else %>
-            <li class="p-4 font-bold hover:text-blue-800">
-              <%= link_to ' ➡️ Login', new_session_path %>
-            </li>
-            <li class="p-4 font-bold hover:text-blue-800">
-              <%= link_to '✍️ Sign up', new_user_path %>
-            </li>
-            <li class="p-4 font-bold hover:text-blue-800">
-              <%= link_to '✴️ FAQ', faq_path %>
-            </li>
-          <% end %>
-        </ul>
-      </nav>
-    </section>
+    <main class="flex-grow" style="padding: 24px 16px;">
+      <% if notice.present? %>
+        <div role="status"
+             class="mx-auto mb-5 inline-block"
+             style="max-width: 1280px;
+                    padding: 10px 14px;
+                    border-radius: 12px;
+                    background-color: var(--color-coop-primary-soft);
+                    color: var(--color-coop-ink);
+                    font-family: var(--font-body);
+                    font-weight: 600;
+                    font-size: 14px;"
+             id="notice">
+          <%= notice %>
+        </div>
+      <% end %>
 
-    <main class="p-6 text-center flex-grow">
-    <% if notice.present? %>
-      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium 
-        rounded-md inline-block" id="notice">
-        <%= notice %>
-      </p>
-    <% end %>
-    <%= yield %>
+      <div class="mx-auto" style="max-width: 1280px;">
+        <%= yield %>
+      </div>
     </main>
 
+    <footer class="mx-auto"
+            style="max-width: 1280px;
+                   padding: 32px 20px 24px;
+                   border-top: 1px solid var(--color-coop-line);
+                   color: var(--color-coop-ink-soft);
+                   font-size: 13px;
+                   text-align: center;">
+      <ul class="flex flex-wrap justify-center gap-5 list-none mb-3" style="font-family: var(--font-body); font-weight: 600;">
+        <li><%= link_to "How it works", how_it_works_path, style: "color: inherit; text-decoration: none;" %></li>
+        <li><%= link_to "FAQ", faq_path, style: "color: inherit; text-decoration: none;" %></li>
+        <li><%= link_to "Acknowledgments", acknowledgements_path, style: "color: inherit; text-decoration: none;" %></li>
+      </ul>
+      <p style="font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.05em;">
+        © AJ <%= Time.now.year %>
+      </p>
+    </footer>
   </body>
-  <footer class="text-center bg-blue-100 py-5">
-    <div class="flex flex-row gap-5 justify-self-center">
-      <div>
-        <ul class="list-none p-2 text-sm">
-          <li class="hover:text-amber-700 hover:cursor-pointer">
-            <%= link_to "How it Works", how_it_works_path %>
-          </li>
-          <li class="hover:text-amber-700 hover:cursor-pointer">
-            <%= link_to "FAQ", faq_path %>
-          </li>
-          <li class="hover:text-amber-700">
-            <%= link_to "Acknowledgments", acknowledgements_path %>
-          </li>
-        </ul>
-      </div>
-    </div>
-    
-    <p class="font-semibold mt-4 text-xs">
-      ©️ AJ <%= Time.now.year %>
-    </p>
-
-  </footer>
 </html>

--- a/app/views/marketing/hello.html.erb
+++ b/app/views/marketing/hello.html.erb
@@ -1,17 +1,37 @@
-<h1 class="font-extrabold text-lime-700 text-4xl">Welcome to</h1>
-<h2 class="font-extrabold text-lime-800 text-7xl pb-7">Henventory</h2>
+<div class="coop-card mx-auto" style="max-width: 720px; padding: 40px 32px; text-align: center;">
+  <div class="coop-kicker mb-3">A backyard egg tracker</div>
 
-<div class>
-  <p class="font-bold text-lime-800 text-lg">The egg-tracking app for chicken owners:</p>
-  <p class="font-semibold text-lime-800 italic">from backyard broods to small-scale farms.</p>
-</div>
+  <h1 style="font-family: var(--font-display);
+             font-size: clamp(40px, 6vw, 64px);
+             line-height: 1.05;
+             color: var(--color-coop-ink);
+             letter-spacing: -0.02em;
+             margin-bottom: 8px;">
+    Welcome to <span style="color: var(--color-coop-primary);">Henventory</span>.
+  </h1>
 
-<div class="m-10">
-  <div class="bg-blue-100 hover:bg-blue-200 border border-blue-200 rounded-xl justify-self-center p-5 m-5 font-semibold hover:text-blue-800">
-    <p>👀 see <%= link_to "how it works", how_it_works_path %></p>
+  <p style="font-family: var(--font-body);
+            font-size: 16px;
+            line-height: 1.55;
+            color: var(--color-coop-ink-soft);
+            font-style: italic;
+            max-width: 520px;
+            margin: 0 auto 28px;">
+    The egg-tracking app for chicken owners — from backyard broods to small-scale farms.
+  </p>
+
+  <div class="flex flex-wrap justify-center gap-3" style="margin-top: 16px;">
+    <%= link_to "Sign up", new_user_path,
+          class: "coop-button-primary",
+          style: "text-decoration: none;" %>
+    <%= link_to "Log in", new_session_path,
+          class: "coop-button-secondary",
+          style: "text-decoration: none;" %>
   </div>
 
-  <div class="bg-blue-100 hover:bg-blue-200 border border-blue-200 rounded-xl justify-self-center p-5 m-5 font-semibold hover:text-blue-800">
-    <%= link_to "🤔 got questions?", faq_path %>
+  <div class="flex flex-wrap justify-center gap-4 mt-8"
+       style="font-family: var(--font-body); font-size: 13px; color: var(--color-coop-ink-soft);">
+    <%= link_to "See how it works →", how_it_works_path, style: "color: var(--color-coop-primary); text-decoration: none; font-weight: 700;" %>
+    <%= link_to "Got questions?", faq_path, style: "color: var(--color-coop-ink-soft); text-decoration: none; font-weight: 600;" %>
   </div>
 </div>

--- a/app/views/marketing/home.html.erb
+++ b/app/views/marketing/home.html.erb
@@ -1,24 +1,68 @@
 <% content_for :title, "Henventory - Home" %>
 
-<h1 class="font-extrabold text-blue-500 text-4xl pb-7">
-  Hi, <%= Current.user.display_name %>!
-</h1>
-<div class="bg-blue-100 mb-5 md:shrink-0 w-100 md:w-150 items-center 
-  justify-self-center p-5 rounded-2xl">
-  <h2 class="font-bold text-lime-700 text-2xl pb-7">
-    Eggs collected for <%= local_time(Time.current, '%A, %B %e') %>
-  </h2>
-  <%= render 'collection_entries/egg_emoji_tally' %>
-  <p class="pt-10">
-    (visit 
-      <a href="collection_entries/today" 
-        class="font-bold text-lime-700 hover:text-lime-900">
-        Today's Entries
-      </a> 
-    for more details!)
+<%#
+  Note: this is the interim logged-in home, which gets replaced wholesale
+  in Phase 1 by the redesigned dashboard (greeting + Quick-Log + stat
+  strip + calendar + leaderboard + Today's collections). This polish pass
+  just makes it feel like part of the Coop shell until that lands.
+%>
+<div class="mx-auto" style="max-width: 720px;">
+  <h1 style="font-family: var(--font-display);
+             font-size: clamp(32px, 6vw, 44px);
+             line-height: 1.05;
+             color: var(--color-coop-ink);
+             letter-spacing: -0.02em;
+             margin-bottom: 4px;">
+    Hi, <%= Current.user.display_name %>.
+  </h1>
+  <p style="font-family: var(--font-mono);
+            font-size: 13px;
+            color: var(--color-coop-ink-soft);
+            letter-spacing: 0.05em;
+            margin-bottom: 20px;">
+    <%= local_time(Time.current, '%A, %B %e') %>
   </p>
+
+  <div class="coop-card" style="padding: 22px 24px; margin-bottom: 20px;">
+    <div class="coop-kicker" style="margin-bottom: 8px;">Today's tally</div>
+
+    <% has_eggs = @collection_entries.exists? %>
+    <% if has_eggs %>
+      <p style="font-size: 28px; line-height: 1.2; word-break: break-word;">
+        <% @collection_entries.each do |collection_entry| %>
+          <% collection_entry.egg_entries.sum(:egg_count).times do %>🥚<% end %>
+        <% end %>
+      </p>
+    <% else %>
+      <p style="font-family: var(--font-body);
+                font-size: 14px;
+                color: var(--color-coop-ink-soft);
+                font-style: italic;">
+        Uh oh — none logged yet.
+      </p>
+    <% end %>
+
+    <p style="margin-top: 14px;
+              font-family: var(--font-body);
+              font-size: 13px;
+              color: var(--color-coop-ink-soft);">
+      Visit
+      <%= link_to "today's entries", today_path,
+            style: "color: var(--color-coop-primary); text-decoration: none; font-weight: 700;" %>
+      for more details.
+    </p>
+  </div>
+
+  <div class="flex flex-wrap items-center gap-3" style="margin-bottom: 12px;">
+    <%= link_to "Got some eggs?", new_collection_entry_path,
+          class: "coop-button-primary",
+          style: "text-decoration: none;" %>
+    <p style="font-family: var(--font-body);
+              font-size: 14px;
+              color: var(--color-coop-ink-soft);
+              font-style: italic;
+              margin: 0;">
+      Hope you're having an egg-cellent day. 🐣
+    </p>
+  </div>
 </div>
-<div class="my-10">
-  <%= render 'collection_entries/new_ce_button' %>
-</div>
-<p>Hope you're having an egg-cellent day 🐣</p>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,40 +1,56 @@
-<% content_for :title, "Change Password" %>
+<% content_for :title, "Update password" %>
 
-<h1 class="font-extrabold text-3xl text-amber-700 pb-5">
-  Update your password
-</h1>
-
-<%= tag.div(flash[:alert], style: "color:red") if flash[:alert] %>
-<div class="border-1 rounded-2xl bg-blue-200 text-l text-left 
-  justify-self-center md:shrink-0 w-100 md:w-150 py-5 px-3 
-  justify-items-center">
-  <%= form_with url: password_path(params[:token]), method: :put do |form| %>
-    <div class="bg-blue-50 rounded-2xl text-left mt-3 pl-2 py-1 mb-2 w-85">
-      <%= form.password_field :password, 
-        required: true, 
-        autocomplete: "new-password", 
-        placeholder: "Enter new password", 
-        size: 40,
-        maxlength: 72 %>
+<div class="coop-card mx-auto" style="max-width: 440px; padding: 36px 32px;">
+  <% if flash[:alert] %>
+    <div role="alert"
+         style="padding: 10px 14px;
+                margin-bottom: 16px;
+                border-radius: 12px;
+                background-color: rgba(161, 60, 44, 0.08);
+                border: 1px solid var(--color-coop-danger);
+                color: var(--color-coop-danger);
+                font-size: 13px;
+                font-weight: 600;">
+      <%= flash[:alert] %>
     </div>
-
-    <div class="bg-blue-50 rounded-2xl text-left mt-3 pl-2 py-1 mb-2 w-85">
-      <%= form.password_field :password_confirmation, 
-        required: true, 
-        autocomplete: "new-password", 
-        placeholder: "Repeat new password",
-        size: 40,
-        maxlength: 72 %>
-    </div>
-  <div class="flex flex-col justify-self-center">
-    <%= form.submit "Save",
-      class: 'mt-5 rounded-2xl px-3.5 py-2.5 font-bold text-white bg-amber-600 
-        hover:bg-amber-700 cursor-pointer' %>
-  </div>
   <% end %>
-</div>
 
-<div class="py-6 border border-blue-200 rounded-2xl bg-blue-100 text-lg my-4 
-  w-110 md:w-150 justify-self-center">
-  <%= link_to "⬅️ Back to settings", settings_path %>
+  <div class="coop-kicker" style="margin-bottom: 6px;">Almost there</div>
+  <h1 style="font-family: var(--font-display);
+             font-size: 32px;
+             line-height: 1.1;
+             color: var(--color-coop-ink);
+             letter-spacing: -0.01em;
+             margin-bottom: 22px;">
+    Update your password.
+  </h1>
+
+  <%= form_with url: password_path(params[:token]), method: :put, class: "flex flex-col" do |form| %>
+    <div style="margin-bottom: 14px;">
+      <%= form.label :password, "New password", class: "coop-kicker block", style: "margin-bottom: 6px;" %>
+      <%= form.password_field :password,
+            required: true,
+            autocomplete: "new-password",
+            placeholder: "Enter new password",
+            maxlength: 72,
+            class: "coop-input" %>
+    </div>
+
+    <div style="margin-bottom: 22px;">
+      <%= form.label :password_confirmation, "Confirm new password", class: "coop-kicker block", style: "margin-bottom: 6px;" %>
+      <%= form.password_field :password_confirmation,
+            required: true,
+            autocomplete: "new-password",
+            placeholder: "Repeat new password",
+            maxlength: 72,
+            class: "coop-input" %>
+    </div>
+
+    <%= form.submit "Save", class: "coop-button-primary", style: "justify-content: center; width: 100%;" %>
+  <% end %>
+
+  <div style="margin-top: 20px; text-align: center; font-size: 13px;">
+    <%= link_to "← Back to settings", settings_path,
+          style: "color: var(--color-coop-ink-soft); text-decoration: none; font-weight: 600;" %>
+  </div>
 </div>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,22 +1,54 @@
-<% content_for :title, "Password Reset" %>
+<% content_for :title, "Reset password" %>
 
-<h1 class="font-extrabold text-amber-800 text-4xl pb-7 mb-5">
-  Forgot your password?
-</h1>
+<div class="coop-card mx-auto" style="max-width: 440px; padding: 36px 32px;">
+  <% if flash[:alert] %>
+    <div role="alert"
+         style="padding: 10px 14px;
+                margin-bottom: 16px;
+                border-radius: 12px;
+                background-color: rgba(161, 60, 44, 0.08);
+                border: 1px solid var(--color-coop-danger);
+                color: var(--color-coop-danger);
+                font-size: 13px;
+                font-weight: 600;">
+      <%= flash[:alert] %>
+    </div>
+  <% end %>
 
-<%= tag.div(flash[:alert], style: "color:red") if flash[:alert] %>
+  <div class="coop-kicker" style="margin-bottom: 6px;">Locked out?</div>
+  <h1 style="font-family: var(--font-display);
+             font-size: 32px;
+             line-height: 1.1;
+             color: var(--color-coop-ink);
+             letter-spacing: -0.01em;
+             margin-bottom: 8px;">
+    Forgot your password?
+  </h1>
+  <p style="font-family: var(--font-body);
+            font-size: 14px;
+            color: var(--color-coop-ink-soft);
+            margin-bottom: 22px;
+            line-height: 1.5;">
+    Pop in your email and we'll send you a reset link.
+  </p>
 
-<%= form_with url: passwords_path do |form| %>
-  <%= form.email_field :email_address, 
-    required: true, 
-    autofocus: true, 
-    autocomplete: "username", 
-    placeholder: "Enter your email address", 
-    value: params[:email_address], 
-    class: 'border-1 border-blue-300 focus:bg-blue-50 rounded-lg p-1 mb-5' %>
-  <div>
-    <%= form.submit "Email reset instructions",
-      class: 'text-lg text-white font-semibold hover:bg-lime-700 
-        bg-lime-600 py-2 px-3 rounded-lg' %>
+  <%= form_with url: passwords_path, class: "flex flex-col" do |form| %>
+    <div style="margin-bottom: 18px;">
+      <%= form.label :email_address, "Email", class: "coop-kicker block", style: "margin-bottom: 6px;" %>
+      <%= form.email_field :email_address,
+            required: true,
+            autofocus: true,
+            autocomplete: "username",
+            placeholder: "you@example.com",
+            value: params[:email_address],
+            class: "coop-input" %>
+    </div>
+
+    <%= form.submit "Email reset instructions", class: "coop-button-primary", style: "justify-content: center; width: 100%;" %>
+  <% end %>
+
+  <div style="margin-top: 20px; text-align: center; font-size: 13px;">
+    <%= link_to "← Back to log in", new_session_path,
+          style: "color: var(--color-coop-ink-soft); text-decoration: none; font-weight: 600;" %>
   </div>
-<% end %>
+</div>

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,5 +1,7 @@
 {
   "name": "Henventory",
+  "short_name": "Henventory",
+  "description": "Backyard egg tracker for chicken keepers.",
   "icons": [
     {
       "src": "/icon.png",
@@ -16,7 +18,7 @@
   "start_url": "/",
   "display": "standalone",
   "scope": "/",
-  "description": "Henventory.",
-  "theme_color": "red",
-  "background_color": "red"
+  "theme_color": "#c4622d",
+  "background_color": "#fbf5e9",
+  "orientation": "portrait"
 }

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,34 +1,76 @@
-<%= tag.div(flash[:alert], style: "color:red") if flash[:alert] %>
-<%= tag.div(flash[:notice], style: "color:green") if flash[:notice] %>
+<% content_for :title, "Log in" %>
 
-<h1 class="font-extrabold text-blue-500 text-4xl pb-7">Login</h1>
+<div class="coop-card mx-auto" style="max-width: 440px; padding: 36px 32px;">
+  <% if flash[:alert] %>
+    <div role="alert"
+         style="padding: 10px 14px;
+                margin-bottom: 16px;
+                border-radius: 12px;
+                background-color: rgba(161, 60, 44, 0.08);
+                border: 1px solid var(--color-coop-danger);
+                color: var(--color-coop-danger);
+                font-size: 13px;
+                font-weight: 600;">
+      <%= flash[:alert] %>
+    </div>
+  <% end %>
 
-<div class="mb-10" >
-<%= form_with url: session_path do |form| %>
-  <div class="justify-self-center mb-10 flex flex-col">
-    <%= form.email_field :email_address, 
-      required: true, 
-      autofocus: true, 
-      autocomplete: "username", 
-      placeholder: "Enter your email address", 
-      value: params[:email_address], 
-      class: 'border-1 border-blue-300 focus:bg-blue-50 rounded-lg p-1 mt-1 
-        mb-5' %>
-    <%= form.password_field :password, 
-      required: true, 
-      autocomplete: "current-password", 
-      placeholder: "Enter your password", 
-      maxlength: 72, :size=>"20", 
-      class: 'border-1 border-blue-300 focus:bg-blue-50 rounded-lg p-1' %>
+  <% if flash[:notice] %>
+    <div role="status"
+         style="padding: 10px 14px;
+                margin-bottom: 16px;
+                border-radius: 12px;
+                background-color: var(--color-coop-primary-soft);
+                color: var(--color-coop-ink);
+                font-size: 13px;
+                font-weight: 600;">
+      <%= flash[:notice] %>
+    </div>
+  <% end %>
+
+  <div class="coop-kicker" style="margin-bottom: 6px;">Welcome back</div>
+  <h1 style="font-family: var(--font-display);
+             font-size: 36px;
+             line-height: 1.1;
+             color: var(--color-coop-ink);
+             letter-spacing: -0.01em;
+             margin-bottom: 24px;">
+    Log in.
+  </h1>
+
+  <%= form_with url: session_path, class: "flex flex-col" do |form| %>
+    <div style="margin-bottom: 14px;">
+      <%= form.label :email_address, "Email", class: "coop-kicker block", style: "margin-bottom: 6px;" %>
+      <%= form.email_field :email_address,
+            required: true,
+            autofocus: true,
+            autocomplete: "username",
+            placeholder: "you@example.com",
+            value: params[:email_address],
+            class: "coop-input" %>
+    </div>
+
+    <div style="margin-bottom: 20px;">
+      <%= form.label :password, "Password", class: "coop-kicker block", style: "margin-bottom: 6px;" %>
+      <%= form.password_field :password,
+            required: true,
+            autocomplete: "current-password",
+            placeholder: "••••••••",
+            maxlength: 72,
+            class: "coop-input" %>
+    </div>
+
+    <%= form.submit "Sign in", class: "coop-button-primary", style: "justify-content: center; width: 100%;" %>
+  <% end %>
+
+  <div style="margin-top: 20px; text-align: center; font-size: 13px;">
+    <%= link_to "Forgot your password?", new_password_path,
+          style: "color: var(--color-coop-ink-soft); text-decoration: none; font-weight: 600;" %>
   </div>
-  <div>
-    <%= form.submit "Sign in",
-      class: 'text-2xl text-white font-semibold hover:font-bold 
-        hover:bg-lime-700 bg-lime-600 py-2 px-3 rounded-lg 
-        justify-self-center' %>
+
+  <div style="margin-top: 8px; text-align: center; font-size: 13px; color: var(--color-coop-ink-soft);">
+    New here?
+    <%= link_to "Sign up", new_user_path,
+          style: "color: var(--color-coop-primary); text-decoration: none; font-weight: 700;" %>
   </div>
-<% end %>
 </div>
-
-<%= link_to "Forgot password?", new_password_path, 
-  class: 'text-blue-900 hover:font-bold' %>

--- a/app/views/shared/_top_bar.html.erb
+++ b/app/views/shared/_top_bar.html.erb
@@ -5,52 +5,42 @@
       user avatar + log-out right.
     - Logged out: wordmark left, marketing nav center, auth buttons right.
 
+  Layout: at >= md (768px+) everything is one row. Below that, the nav
+  drops to its own row underneath the wordmark+actions row, so the
+  primary controls (avatar, log out) never get pushed off-screen by
+  long nav labels. The nav row itself horizontally scrolls if the labels
+  overflow — visible scroll is suppressed; the snap/FAB pattern from
+  Phase 1 will replace this with proper mobile chrome.
+
   Active nav state is driven by `current_page?`. Inactive items use
   --coop-ink-soft on transparent; active uses --coop-primary-soft bg
   with --coop-ink text.
-
-  Layout reserves a horizontal scroll on the nav row at narrow widths
-  (overflow-x-auto on the nav UL). Mobile snap-scroll and a bottom FAB
-  are layered on by Phase 1.
 %>
-<header class="coop-card mx-auto" style="max-width: 1280px; margin-top: 16px; padding: 14px 20px;">
-  <div class="flex items-center justify-between gap-4">
-    <%# Wordmark — links home %>
+<header class="coop-card mx-auto"
+        style="max-width: 1280px; margin: 16px 12px 0; padding: 14px 16px;">
+  <%# Row 1: wordmark + right cluster. Nav joins this row at md+. %>
+  <div class="flex items-center justify-between gap-3">
     <%= link_to (Current.user ? landing_path : root_path), class: "shrink-0", "aria-label": "Henventory home" do %>
       <%= render "shared/wordmark", size: :md %>
     <% end %>
 
-    <%# Center nav %>
+    <%# Inline nav slot — visible only at md+. Mobile uses the row below. %>
     <% if Current.user %>
       <% layer_mode = Current.user.mode == "layer" %>
       <%
         nav_items = [
-          { label: "Today",       path: today_path,             active: current_page?(today_path) },
+          { label: "Today",       path: today_path,              active: current_page?(today_path) },
           { label: "All Entries", path: collection_entries_path, active: current_page?(collection_entries_path) },
-          ({ label: "My Flock",  path: chickens_path,           active: current_page?(chickens_path) } if layer_mode),
+          ({ label: "My Flock",   path: chickens_path,           active: current_page?(chickens_path) } if layer_mode),
           { label: "Settings",    path: settings_path,           active: current_page?(settings_path) }
         ].compact
       %>
-      <nav aria-label="Primary" class="min-w-0">
+      <nav aria-label="Primary" class="hidden md:block min-w-0">
         <ul class="flex items-center gap-1 overflow-x-auto" style="scrollbar-width: none;">
-          <% nav_items.each do |item| %>
-            <li class="shrink-0">
-              <%= link_to item[:label], item[:path],
-                    class: "inline-block whitespace-nowrap",
-                    style: "padding: 8px 14px;
-                            border-radius: 10px;
-                            font-family: var(--font-body);
-                            font-size: 13px;
-                            font-weight: 600;
-                            color: #{item[:active] ? 'var(--color-coop-ink)' : 'var(--color-coop-ink-soft)'};
-                            background-color: #{item[:active] ? 'var(--color-coop-primary-soft)' : 'transparent'};
-                            text-decoration: none;" %>
-            </li>
-          <% end %>
+          <%= render "shared/top_bar_nav_items", items: nav_items %>
         </ul>
       </nav>
 
-      <%# Right cluster: avatar + log-out %>
       <div class="flex items-center gap-2 shrink-0">
         <%= render "shared/user_avatar", user: Current.user, size: 36 %>
         <%= button_to "Log out", session_path,
@@ -59,33 +49,33 @@
               style: "padding: 8px 14px; font-size: 12px;" %>
       </div>
     <% else %>
-      <%# Logged-out: marketing nav + auth buttons %>
-      <nav aria-label="Primary" class="min-w-0">
+      <%
+        nav_items = [
+          { label: "How It Works", path: how_it_works_path, active: current_page?(how_it_works_path) },
+          { label: "FAQ",          path: faq_path,          active: current_page?(faq_path) }
+        ]
+      %>
+      <nav aria-label="Primary" class="hidden md:block min-w-0">
         <ul class="flex items-center gap-1 overflow-x-auto" style="scrollbar-width: none;">
-          <% [
-            { label: "How It Works", path: how_it_works_path, active: current_page?(how_it_works_path) },
-            { label: "FAQ",           path: faq_path,           active: current_page?(faq_path) }
-          ].each do |item| %>
-            <li class="shrink-0">
-              <%= link_to item[:label], item[:path],
-                    class: "inline-block whitespace-nowrap",
-                    style: "padding: 8px 14px;
-                            border-radius: 10px;
-                            font-family: var(--font-body);
-                            font-size: 13px;
-                            font-weight: 600;
-                            color: #{item[:active] ? 'var(--color-coop-ink)' : 'var(--color-coop-ink-soft)'};
-                            background-color: #{item[:active] ? 'var(--color-coop-primary-soft)' : 'transparent'};
-                            text-decoration: none;" %>
-            </li>
-          <% end %>
+          <%= render "shared/top_bar_nav_items", items: nav_items %>
         </ul>
       </nav>
 
       <div class="flex items-center gap-2 shrink-0">
-        <%= link_to "Log in", new_session_path, class: "coop-button-secondary", style: "padding: 8px 14px; font-size: 12px; text-decoration: none;" %>
-        <%= link_to "Sign up", new_user_path,    class: "coop-button-primary",   style: "padding: 8px 14px; font-size: 12px; text-decoration: none;" %>
+        <%= link_to "Log in", new_session_path,
+              class: "coop-button-secondary",
+              style: "padding: 8px 14px; font-size: 12px; text-decoration: none;" %>
+        <%= link_to "Sign up", new_user_path,
+              class: "coop-button-primary",
+              style: "padding: 8px 14px; font-size: 12px; text-decoration: none;" %>
       </div>
     <% end %>
   </div>
+
+  <%# Row 2: nav, mobile only. Hidden at md+ since it appears inline above. %>
+  <nav aria-label="Primary (mobile)" class="md:hidden mt-3 min-w-0">
+    <ul class="flex items-center gap-1 overflow-x-auto" style="scrollbar-width: none; -webkit-overflow-scrolling: touch;">
+      <%= render "shared/top_bar_nav_items", items: nav_items %>
+    </ul>
+  </nav>
 </header>

--- a/app/views/shared/_top_bar.html.erb
+++ b/app/views/shared/_top_bar.html.erb
@@ -16,6 +16,27 @@
   --coop-ink-soft on transparent; active uses --coop-primary-soft bg
   with --coop-ink text.
 %>
+<%
+  # Build nav_items up front so both the inline (md+) row and the mobile
+  # (md-) row reference the same value. Previously this was defined inside
+  # an if/else, which worked because ERB shares scope but silently 500'd
+  # if anyone removed a branch. Issue C from the Phase 0 code review.
+  nav_items =
+    if Current.user
+      layer_mode = Current.user.mode == "layer"
+      [
+        { label: "Today",       path: today_path,              active: current_page?(today_path) },
+        { label: "All Entries", path: collection_entries_path, active: current_page?(collection_entries_path) },
+        ({ label: "My Flock",   path: chickens_path,           active: current_page?(chickens_path) } if layer_mode),
+        { label: "Settings",    path: settings_path,           active: current_page?(settings_path) }
+      ].compact
+    else
+      [
+        { label: "How It Works", path: how_it_works_path, active: current_page?(how_it_works_path) },
+        { label: "FAQ",          path: faq_path,          active: current_page?(faq_path) }
+      ]
+    end
+%>
 <header class="coop-card mx-auto"
         style="max-width: 1280px; margin: 16px 12px 0; padding: 14px 16px;">
   <%# Row 1: wordmark + right cluster. Nav joins this row at md+. %>
@@ -25,22 +46,14 @@
     <% end %>
 
     <%# Inline nav slot — visible only at md+. Mobile uses the row below. %>
-    <% if Current.user %>
-      <% layer_mode = Current.user.mode == "layer" %>
-      <%
-        nav_items = [
-          { label: "Today",       path: today_path,              active: current_page?(today_path) },
-          { label: "All Entries", path: collection_entries_path, active: current_page?(collection_entries_path) },
-          ({ label: "My Flock",   path: chickens_path,           active: current_page?(chickens_path) } if layer_mode),
-          { label: "Settings",    path: settings_path,           active: current_page?(settings_path) }
-        ].compact
-      %>
-      <nav aria-label="Primary" class="hidden md:block min-w-0">
-        <ul class="flex items-center gap-1 overflow-x-auto" style="scrollbar-width: none;">
-          <%= render "shared/top_bar_nav_items", items: nav_items %>
-        </ul>
-      </nav>
+    <nav aria-label="Primary" class="hidden md:block min-w-0">
+      <ul class="flex items-center gap-1 overflow-x-auto" style="scrollbar-width: none;">
+        <%= render "shared/top_bar_nav_items", items: nav_items %>
+      </ul>
+    </nav>
 
+    <%# Right cluster: avatar+logout when authed, auth buttons otherwise. %>
+    <% if Current.user %>
       <div class="flex items-center gap-2 shrink-0">
         <%= render "shared/user_avatar", user: Current.user, size: 36 %>
         <%= button_to "Log out", session_path,
@@ -49,18 +62,6 @@
               style: "padding: 8px 14px; font-size: 12px;" %>
       </div>
     <% else %>
-      <%
-        nav_items = [
-          { label: "How It Works", path: how_it_works_path, active: current_page?(how_it_works_path) },
-          { label: "FAQ",          path: faq_path,          active: current_page?(faq_path) }
-        ]
-      %>
-      <nav aria-label="Primary" class="hidden md:block min-w-0">
-        <ul class="flex items-center gap-1 overflow-x-auto" style="scrollbar-width: none;">
-          <%= render "shared/top_bar_nav_items", items: nav_items %>
-        </ul>
-      </nav>
-
       <div class="flex items-center gap-2 shrink-0">
         <%= link_to "Log in", new_session_path,
               class: "coop-button-secondary",

--- a/app/views/shared/_top_bar.html.erb
+++ b/app/views/shared/_top_bar.html.erb
@@ -1,0 +1,91 @@
+<%#
+  Coop top bar. Sits above page content. Two states:
+
+    - Logged in: wordmark left, primary nav center (pill buttons),
+      user avatar + log-out right.
+    - Logged out: wordmark left, marketing nav center, auth buttons right.
+
+  Active nav state is driven by `current_page?`. Inactive items use
+  --coop-ink-soft on transparent; active uses --coop-primary-soft bg
+  with --coop-ink text.
+
+  Layout reserves a horizontal scroll on the nav row at narrow widths
+  (overflow-x-auto on the nav UL). Mobile snap-scroll and a bottom FAB
+  are layered on by Phase 1.
+%>
+<header class="coop-card mx-auto" style="max-width: 1280px; margin-top: 16px; padding: 14px 20px;">
+  <div class="flex items-center justify-between gap-4">
+    <%# Wordmark — links home %>
+    <%= link_to (Current.user ? landing_path : root_path), class: "shrink-0", "aria-label": "Henventory home" do %>
+      <%= render "shared/wordmark", size: :md %>
+    <% end %>
+
+    <%# Center nav %>
+    <% if Current.user %>
+      <% layer_mode = Current.user.mode == "layer" %>
+      <%
+        nav_items = [
+          { label: "Today",       path: today_path,             active: current_page?(today_path) },
+          { label: "All Entries", path: collection_entries_path, active: current_page?(collection_entries_path) },
+          ({ label: "My Flock",  path: chickens_path,           active: current_page?(chickens_path) } if layer_mode),
+          { label: "Settings",    path: settings_path,           active: current_page?(settings_path) }
+        ].compact
+      %>
+      <nav aria-label="Primary" class="min-w-0">
+        <ul class="flex items-center gap-1 overflow-x-auto" style="scrollbar-width: none;">
+          <% nav_items.each do |item| %>
+            <li class="shrink-0">
+              <%= link_to item[:label], item[:path],
+                    class: "inline-block whitespace-nowrap",
+                    style: "padding: 8px 14px;
+                            border-radius: 10px;
+                            font-family: var(--font-body);
+                            font-size: 13px;
+                            font-weight: 600;
+                            color: #{item[:active] ? 'var(--color-coop-ink)' : 'var(--color-coop-ink-soft)'};
+                            background-color: #{item[:active] ? 'var(--color-coop-primary-soft)' : 'transparent'};
+                            text-decoration: none;" %>
+            </li>
+          <% end %>
+        </ul>
+      </nav>
+
+      <%# Right cluster: avatar + log-out %>
+      <div class="flex items-center gap-2 shrink-0">
+        <%= render "shared/user_avatar", user: Current.user, size: 36 %>
+        <%= button_to "Log out", session_path,
+              method: :delete,
+              class: "coop-button-secondary",
+              style: "padding: 8px 14px; font-size: 12px;" %>
+      </div>
+    <% else %>
+      <%# Logged-out: marketing nav + auth buttons %>
+      <nav aria-label="Primary" class="min-w-0">
+        <ul class="flex items-center gap-1 overflow-x-auto" style="scrollbar-width: none;">
+          <% [
+            { label: "How It Works", path: how_it_works_path, active: current_page?(how_it_works_path) },
+            { label: "FAQ",           path: faq_path,           active: current_page?(faq_path) }
+          ].each do |item| %>
+            <li class="shrink-0">
+              <%= link_to item[:label], item[:path],
+                    class: "inline-block whitespace-nowrap",
+                    style: "padding: 8px 14px;
+                            border-radius: 10px;
+                            font-family: var(--font-body);
+                            font-size: 13px;
+                            font-weight: 600;
+                            color: #{item[:active] ? 'var(--color-coop-ink)' : 'var(--color-coop-ink-soft)'};
+                            background-color: #{item[:active] ? 'var(--color-coop-primary-soft)' : 'transparent'};
+                            text-decoration: none;" %>
+            </li>
+          <% end %>
+        </ul>
+      </nav>
+
+      <div class="flex items-center gap-2 shrink-0">
+        <%= link_to "Log in", new_session_path, class: "coop-button-secondary", style: "padding: 8px 14px; font-size: 12px; text-decoration: none;" %>
+        <%= link_to "Sign up", new_user_path,    class: "coop-button-primary",   style: "padding: 8px 14px; font-size: 12px; text-decoration: none;" %>
+      </div>
+    <% end %>
+  </div>
+</header>

--- a/app/views/shared/_top_bar_nav_items.html.erb
+++ b/app/views/shared/_top_bar_nav_items.html.erb
@@ -1,0 +1,21 @@
+<%#
+  Renders the nav <li> pill items inside a <ul>. Used by both the
+  inline (md+) and mobile (md-) nav rows in the top bar.
+
+  Locals:
+    items: Array of { label:, path:, active: } hashes.
+%>
+<% items.each do |item| %>
+  <li class="shrink-0">
+    <%= link_to item[:label], item[:path],
+          class: "inline-block whitespace-nowrap",
+          style: "padding: 8px 14px;
+                  border-radius: 10px;
+                  font-family: var(--font-body);
+                  font-size: 13px;
+                  font-weight: 600;
+                  color: #{item[:active] ? 'var(--color-coop-ink)' : 'var(--color-coop-ink-soft)'};
+                  background-color: #{item[:active] ? 'var(--color-coop-primary-soft)' : 'transparent'};
+                  text-decoration: none;" %>
+  </li>
+<% end %>

--- a/app/views/shared/_user_avatar.html.erb
+++ b/app/views/shared/_user_avatar.html.erb
@@ -1,0 +1,33 @@
+<%#
+  Compact user avatar — initials in a colored circle, used in the top bar.
+
+  Locals:
+    user: a User record
+    size: pixel size (default 36)
+
+  No image upload exists today; this is a deterministic initials avatar.
+  When/if images get added, swap the inner content with an <img> while
+  keeping the wrapper styling.
+%>
+<% user = local_assigns.fetch(:user) %>
+<% size = local_assigns.fetch(:size, 36) %>
+<%
+  initials =
+    if user.display_name.present?
+      user.display_name.split.first(2).map { |s| s[0].upcase }.join
+    else
+      (user.email_address.presence || "??").to_s[0, 2].upcase
+    end
+%>
+
+<span aria-label="Account"
+      class="inline-flex items-center justify-center rounded-full font-bold"
+      style="width: <%= size %>px;
+             height: <%= size %>px;
+             background-color: var(--color-coop-bg-alt);
+             color: var(--color-coop-ink);
+             font-family: var(--font-body);
+             font-size: <%= (size * 0.39).round %>px;
+             border: 1px solid var(--color-coop-line);">
+  <%= initials %>
+</span>

--- a/app/views/shared/_wordmark.html.erb
+++ b/app/views/shared/_wordmark.html.erb
@@ -1,0 +1,28 @@
+<%#
+  Henventory wordmark. Used in the top bar, footer, and marketing pages.
+
+  Locals:
+    size: :sm | :md | :lg  (default :md)
+
+  Renders the word "Henventory" in display type, with "ventory" colored
+  in the Coop primary terracotta, followed by a small egg-shaped mark.
+  The two-tone split mirrors the brand direction's wordmark.
+%>
+<% size = local_assigns.fetch(:size, :md) %>
+<% font_size_class = { sm: "text-xl", md: "text-2xl", lg: "text-4xl" }.fetch(size) %>
+<% egg_size_px = { sm: 7, md: 9, lg: 13 }.fetch(size) %>
+<% egg_h_px = (egg_size_px * 1.45).round %>
+
+<span class="inline-flex items-baseline gap-1.5"
+      style="font-family: var(--font-display); line-height: 1;">
+  <span class="<%= font_size_class %> font-normal" style="color: var(--color-coop-ink); letter-spacing: -0.01em;">
+    Hen<span style="color: var(--color-coop-primary);">ventory</span>
+  </span>
+  <span aria-hidden="true"
+        style="display: inline-block;
+               width: <%= egg_size_px %>px;
+               height: <%= egg_h_px %>px;
+               background: var(--color-coop-primary);
+               border-radius: 50% 50% 50% 50% / 60% 60% 40% 40%;
+               transform: rotate(-8deg) translateY(-2px);"></span>
+</span>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,68 +1,149 @@
-<% content_for :title, "Sign Up" %>
+<% content_for :title, "Sign up" %>
 
-<h1 class="font-extrabold text-3xl text-lime-700">Sign Up</h1>
-<p class="pb-5">(We're egg-cited to meet you.)</p>
+<div class="coop-card mx-auto" style="max-width: 480px; padding: 36px 32px;">
+  <div class="coop-kicker" style="margin-bottom: 6px;">Welcome to the coop</div>
+  <h1 style="font-family: var(--font-display);
+             font-size: 36px;
+             line-height: 1.1;
+             color: var(--color-coop-ink);
+             letter-spacing: -0.01em;
+             margin-bottom: 8px;">
+    Sign up.
+  </h1>
+  <p style="font-family: var(--font-body);
+            font-size: 14px;
+            color: var(--color-coop-ink-soft);
+            font-style: italic;
+            margin-bottom: 24px;">
+    We're egg-cited to meet you.
+  </p>
 
-<% if @household %>
-  <div class="p-10 mb-5 bg-green-50 rounded-2xl border-1 border-green-100 w-1/2 justify-self-center text-xl font-bold">
-    <p>You've been invited to join the <%= @household.name %> household!</p>
-  </div>
-<% end %>
-
-<div class="border-1 rounded-2xl bg-blue-200 text-l text-left justify-self-center md:shrink-0 w-100 md:w-150 pt-5 px-3 pb-5 justify-items-center">
-  <%= form_for :user, url: '/users' do |form| %>
-    <div class="bg-blue-50 rounded-2xl text-left mt-3 pl-2 py-1 mb-2 w-85">
-      <%= form.label :display_name, "Name: ", class: 'font-bold' %>
-      <%= form.text_field :display_name, class: 'font-semibold w-65' %>
+  <% if @household %>
+    <div role="status"
+         style="padding: 14px 16px;
+                margin-bottom: 20px;
+                border-radius: 12px;
+                background-color: var(--color-coop-primary-soft);
+                color: var(--color-coop-ink);
+                font-size: 14px;
+                font-weight: 600;
+                line-height: 1.4;">
+      You've been invited to join the <strong><%= @household.name %></strong> household!
     </div>
+  <% end %>
 
-    <div>
-      <% if @household %>
-        <%= hidden_field_tag 'household[invite_token]', @household.invite_token %>
-        <%= hidden_field_tag 'user[skip_account_seed]' %>
-      <% end %>
-    </div>
-
-    <div class="bg-blue-50 rounded-2xl text-left mt-3 pl-2 py-1 mb-2 w-85">
-      <%= form.label :mode, "Mode: ", class: 'font-bold pr-2' %>
-      <%= form.radio_button :mode, "flock" %>
-      <%= form.label :mode_flock, "Flock", class: 'pr-2' %>   
-      <%= form.radio_button :mode, "layer" %>
-      <%= form.label :mode_layer, "Layer" %>
-      <p class="inline mx-2 px-2 bg-blue-200 rounded-2xl opacity-50 hover:opacity-90 w-fit"><a href="/faq#anchor-one" target="_blank">🤔 What's this?</a></p>
+  <%= form_for :user, url: '/users', html: { class: "flex flex-col" } do |form| %>
+    <div style="margin-bottom: 14px;">
+      <%= form.label :display_name, "Name", class: "coop-kicker block", style: "margin-bottom: 6px;" %>
+      <%= form.text_field :display_name, class: "coop-input" %>
     </div>
 
     <% if @household %>
-      <div class="text-xs w-80 px-2 text-justify">
-        <p>(If you've read the 'What's This?' link above and you're still not sure which mode to choose, ask the person who invited you.)</p>
-      </div>
+      <%= hidden_field_tag 'household[invite_token]', @household.invite_token %>
+      <%= hidden_field_tag 'user[skip_account_seed]' %>
     <% end %>
-    
-    <div class="bg-blue-100 rounded-2xl text-left mt-3 pl-2 py-1 mb-2 w-85"> 
-      <%= form.label :email_address, "Email: ", class: 'font-bold' %>
-      <%= form.text_field :email_address, class: 'font-semibold w-65' %>
+
+    <div style="margin-bottom: 14px;">
+      <div class="coop-kicker" style="margin-bottom: 6px; display: flex; align-items: center; gap: 8px;">
+        <span>Mode</span>
+        <%= link_to "What's this?", "/faq#anchor-one", target: "_blank",
+              style: "color: var(--color-coop-primary); text-decoration: none; font-weight: 700; letter-spacing: 0;" %>
+      </div>
+      <div class="flex gap-2">
+        <label style="flex: 1; cursor: pointer;">
+          <%= form.radio_button :mode, "flock", style: "position: absolute; opacity: 0; pointer-events: none;",
+                class: "coop-mode-radio", data: { mode: "flock" } %>
+          <span class="coop-mode-option" style="display: block;
+                                                 padding: 10px 14px;
+                                                 border-radius: 12px;
+                                                 background-color: var(--color-coop-bg-alt);
+                                                 border: 1px solid var(--color-coop-line);
+                                                 font-family: var(--font-body);
+                                                 font-weight: 700;
+                                                 font-size: 13px;
+                                                 text-align: center;
+                                                 transition: background-color 120ms, color 120ms;">
+            Flock
+          </span>
+        </label>
+        <label style="flex: 1; cursor: pointer;">
+          <%= form.radio_button :mode, "layer", style: "position: absolute; opacity: 0; pointer-events: none;",
+                class: "coop-mode-radio", data: { mode: "layer" } %>
+          <span class="coop-mode-option" style="display: block;
+                                                 padding: 10px 14px;
+                                                 border-radius: 12px;
+                                                 background-color: var(--color-coop-bg-alt);
+                                                 border: 1px solid var(--color-coop-line);
+                                                 font-family: var(--font-body);
+                                                 font-weight: 700;
+                                                 font-size: 13px;
+                                                 text-align: center;
+                                                 transition: background-color 120ms, color 120ms;">
+            Layer
+          </span>
+        </label>
+      </div>
+      <% if @household %>
+        <p style="margin-top: 8px;
+                  font-size: 12px;
+                  color: var(--color-coop-ink-soft);
+                  font-style: italic;
+                  line-height: 1.4;">
+          If you've read the "What's this?" link above and you're still not sure which mode to choose, ask the person who invited you.
+        </p>
+      <% end %>
     </div>
 
-    <div class="bg-blue-50 rounded-2xl text-left mt-3 pl-2 py-1 mb-2 w-85">
-      <%= form.label :password, "Password: ", class: 'font-bold' %>
-      <%= form.password_field :password, class: 'font-semibold w-60' %>
+    <div style="margin-bottom: 14px;">
+      <%= form.label :email_address, "Email", class: "coop-kicker block", style: "margin-bottom: 6px;" %>
+      <%= form.text_field :email_address, class: "coop-input" %>
     </div>
 
-    <div class="bg-blue-100 rounded-2xl text-left mt-3 pl-2 py-1 mb-2 w-85">
-      <%= form.label :password_confirmation, "Confirm Password: ", class: 'font-bold' %>
-      <%= form.password_field :password_confirmation %>
+    <div style="margin-bottom: 14px;">
+      <%= form.label :password, "Password", class: "coop-kicker block", style: "margin-bottom: 6px;" %>
+      <%= form.password_field :password, class: "coop-input" %>
     </div>
-    <div>
-      <%= hidden_field_tag 'household[time_zone]', nil, id: 'user-time-zone' %>
+
+    <div style="margin-bottom: 22px;">
+      <%= form.label :password_confirmation, "Confirm password", class: "coop-kicker block", style: "margin-bottom: 6px;" %>
+      <%= form.password_field :password_confirmation, class: "coop-input" %>
     </div>
-    <div class="flex flex-col justify-self-center">
-      <%= form.submit "Submit",
-        class: 'mt-5 font-bold text-white bg-lime-600 hover:bg-lime-700 p-3 
-      rounded-2xl align-self-center justify-self-center' %>
-    </div>
+
+    <%= hidden_field_tag 'household[time_zone]', nil, id: 'user-time-zone' %>
+
+    <%= form.submit "Create account", class: "coop-button-primary", style: "justify-content: center; width: 100%;" %>
   <% end %>
+
+  <div style="margin-top: 20px; text-align: center; font-size: 13px; color: var(--color-coop-ink-soft);">
+    Already have an account?
+    <%= link_to "Log in", new_session_path,
+          style: "color: var(--color-coop-primary); text-decoration: none; font-weight: 700;" %>
+  </div>
 </div>
 
 <script>
   document.querySelector('#user-time-zone').value = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  // Light-touch segmented control: hide the radio inputs visually,
+  // restyle the adjacent <span> when checked.
+  (function() {
+    const labels = document.querySelectorAll('label > input.coop-mode-radio');
+    function refresh() {
+      labels.forEach(input => {
+        const span = input.nextElementSibling;
+        if (!span) return;
+        if (input.checked) {
+          span.style.backgroundColor = 'var(--color-coop-primary)';
+          span.style.color = 'var(--color-coop-cream)';
+          span.style.borderColor = 'var(--color-coop-primary)';
+        } else {
+          span.style.backgroundColor = 'var(--color-coop-bg-alt)';
+          span.style.color = 'var(--color-coop-ink)';
+          span.style.borderColor = 'var(--color-coop-line)';
+        }
+      });
+    }
+    labels.forEach(input => input.addEventListener('change', refresh));
+    refresh();
+  })();
 </script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,9 +25,9 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
-  # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
-  # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-  # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
+  # Render dynamic PWA files from app/views/pwa/*. Linked in application.html.erb.
+  get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
+  get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   # Defines the root path route ("/")
 root "marketing#hello"

--- a/db/migrate/20260507144746_add_accent_colors_to_chickens.rb
+++ b/db/migrate/20260507144746_add_accent_colors_to_chickens.rb
@@ -1,0 +1,6 @@
+class AddAccentColorsToChickens < ActiveRecord::Migration[8.0]
+  def change
+    add_column :chickens, :accent_color, :string
+    add_column :chickens, :accent_secondary, :string
+  end
+end

--- a/db/migrate/20260507165548_backfill_chicken_accent_colors.rb
+++ b/db/migrate/20260507165548_backfill_chicken_accent_colors.rb
@@ -1,0 +1,40 @@
+class BackfillChickenAccentColors < ActiveRecord::Migration[8.0]
+  # Backfills accent_color (and accent_secondary for patterned breeds) on
+  # existing chickens by matching their `breed` string against the
+  # Chicken::BREED_TINTS registry. Chickens whose breed doesn't match any
+  # registry entry are left with NULL accents; they'll either get accents
+  # picked up if the breed is later edited to a known value, or via the
+  # Custom-breed picker on the redesigned New Chicken form.
+  #
+  # Safe to run inline: dataset is < 1000 rows. Wrapped in a transaction by
+  # default (ActiveRecord::Migration). Idempotent: skips chickens that
+  # already have an accent_color set.
+  def up
+    # Use a lightweight anonymous model to avoid coupling this migration to
+    # whatever future shape Chicken takes. We only need read/write of
+    # breed, accent_color, accent_secondary.
+    chicken_model = Class.new(ActiveRecord::Base) do
+      self.table_name = "chickens"
+    end
+
+    tints = Chicken::BREED_TINTS
+
+    chicken_model.where(accent_color: nil).find_each do |row|
+      next if row.breed.blank?
+
+      match = tints.find { |b| b[:name].casecmp?(row.breed.to_s.strip) }
+      next unless match
+
+      row.update_columns(
+        accent_color: match[:tint],
+        accent_secondary: match[:secondary]
+      )
+    end
+  end
+
+  def down
+    # Non-destructive backfill; nothing to roll back. Leaving as a no-op so
+    # rolling back this migration doesn't wipe out any subsequent
+    # user-edited accent values.
+  end
+end

--- a/db/migrate/20260507192705_backfill_production_blue_accents.rb
+++ b/db/migrate/20260507192705_backfill_production_blue_accents.rb
@@ -1,0 +1,29 @@
+class BackfillProductionBlueAccents < ActiveRecord::Migration[8.0]
+  # Adds the Production Blue tint retroactively. The original
+  # BackfillChickenAccentColors migration ran before Production Blue was
+  # in the BREED_TINTS registry, so any Production Blues created before
+  # this migration ran are sitting with NULL accents.
+  #
+  # Idempotent: only touches rows where accent_color is nil and breed
+  # matches "Production Blue" case-insensitively. Won't disturb
+  # user-edited accents (e.g., custom-color picker selections in Phase 2+).
+  #
+  # Safe to run inline at any household scale we expect (< 1000 rows).
+  def up
+    chicken_model = Class.new(ActiveRecord::Base) do
+      self.table_name = "chickens"
+    end
+
+    match = Chicken::BREED_TINTS.find { |b| b[:name].casecmp?("Production Blue") }
+    return unless match # safety: silently no-op if the tint was renamed/removed
+
+    chicken_model.where(accent_color: nil)
+      .where("LOWER(TRIM(breed)) = ?", "production blue")
+      .update_all(accent_color: match[:tint])
+  end
+
+  def down
+    # Non-destructive backfill; nothing to roll back. Leaving as a no-op so
+    # rolling back this migration doesn't wipe out user-edited accents.
+  end
+end

--- a/db/migrate/20260508190113_add_dashboard_query_indexes.rb
+++ b/db/migrate/20260508190113_add_dashboard_query_indexes.rb
@@ -1,0 +1,23 @@
+class AddDashboardQueryIndexes < ActiveRecord::Migration[8.0]
+  # Indexes backing the DashboardStats query patterns. Issue B from the
+  # Phase 0 code review — without these, every dashboard read is a
+  # sequential scan + nested-loop join.
+  #
+  # Composite (household_id, created_at) on collection_entries because
+  # every dashboard query is scoped by household AND filtered by a
+  # created_at range; the composite is strictly better than two singles
+  # for that access pattern.
+  #
+  # Straight FK index on egg_entries.collection_entry_id because the
+  # household has_many :egg_entries, through: :collection_entries join
+  # loads egg_entries by `collection_entry_id IN (...)` and Rails doesn't
+  # auto-index FKs on tables created before this migration.
+  #
+  # No index on egg_entries.created_at: with the Fix-A change to filter
+  # by collection_entries.created_at instead, the egg's own timestamp
+  # isn't queried in any hot path.
+  def change
+    add_index :collection_entries, [:household_id, :created_at]
+    add_index :egg_entries, :collection_entry_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_13_153215) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_07_144746) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -25,6 +25,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_13_153215) do
     t.string "image_url"
     t.integer "household_id"
     t.string "status"
+    t.string "accent_color"
+    t.string "accent_secondary"
   end
 
   create_table "collection_entries", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_07_144746) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_07_165548) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_07_192705) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_08_190113) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -37,6 +37,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_07_192705) do
     t.text "notes"
     t.datetime "collected_at"
     t.index ["collected_at"], name: "index_collection_entries_on_collected_at"
+    t.index ["household_id", "created_at"], name: "index_collection_entries_on_household_id_and_created_at"
   end
 
   create_table "egg_entries", force: :cascade do |t|
@@ -45,6 +46,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_07_192705) do
     t.integer "collection_entry_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["collection_entry_id"], name: "index_egg_entries_on_collection_entry_id"
   end
 
   create_table "households", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_07_165548) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_07_192705) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/test/controllers/collection_entries_controller_test.rb
+++ b/test/controllers/collection_entries_controller_test.rb
@@ -23,6 +23,28 @@ class CollectionEntriesControllerTest < ActionDispatch::IntegrationTest
   test "should get today" do
     get today_url
     assert_response :success
+    assert_match(/Today/, @response.body)
+  end
+
+  test "should get today with explicit date param" do
+    target = Date.current - 3.days
+    get today_url(date: target.iso8601)
+    assert_response :success
+    # When viewing a non-today date, the heading reflects the chosen day.
+    assert_match(target.strftime("%b"), @response.body)
+    assert_no_match(/Today's Count/, @response.body)
+  end
+
+  test "should fall back to today when date param is malformed" do
+    get today_url(date: "not-a-date")
+    assert_response :success
+    assert_match(/Today/, @response.body)
+  end
+
+  test "should fall back to today when date param is blank" do
+    get today_url(date: "")
+    assert_response :success
+    assert_match(/Today/, @response.body)
   end
 
   test "should get new" do

--- a/test/queries/dashboard_stats_test.rb
+++ b/test/queries/dashboard_stats_test.rb
@@ -1,0 +1,259 @@
+require "test_helper"
+
+class DashboardStatsTest < ActiveSupport::TestCase
+  # Factory helpers — small, opinionated, hand-built (not using FactoryBot).
+  # Each test gets a fresh household so state never leaks across tests.
+
+  def make_household(time_zone: "UTC")
+    Household.create!(name: "Test Coop #{SecureRandom.hex(3)}", time_zone: time_zone)
+  end
+
+  def make_user(household)
+    User.new(
+      email_address: "u#{SecureRandom.hex(3)}@example.com",
+      password: "password",
+      household: household,
+      mode: "layer"
+    ).tap do |u|
+      u.skip_account_seed = true
+      u.save!
+    end
+  end
+
+  def make_chicken(household, name:, breed: "Rhode Island Red", status: "layer")
+    Chicken.create!(
+      name: name,
+      breed: breed,
+      tell: "tell-#{name}",
+      dob: 1.year.ago,
+      status: status,
+      household: household
+    )
+  end
+
+  # Logs `count` eggs for a chicken at `at` (a Time). The collection_entry
+  # gets created_at = at; the egg_entry inherits the same created_at via
+  # explicit assignment (Rails would otherwise stamp Time.current).
+  def log_eggs(household, user, chicken, count:, at:)
+    entry = household.collection_entries.create!(
+      user: user,
+      created_at: at,
+      updated_at: at,
+      collected_at: at
+    )
+    egg = entry.egg_entries.create!(chicken: chicken, egg_count: count)
+    egg.update_columns(created_at: at, updated_at: at)
+    entry
+  end
+
+  setup do
+    # Pin "now" to a known weekday-Wednesday so beginning_of_week math is
+    # stable: 2026-04-29 is a Wednesday in any TZ.
+    @now = Time.zone.parse("2026-04-29 14:00:00 UTC")
+    @household = make_household
+    @user = make_user(@household)
+  end
+
+  # ---- today_count ----
+
+  test "today_count sums egg counts created today, excludes other days" do
+    chicken = make_chicken(@household, name: "Penelope")
+    log_eggs(@household, @user, chicken, count: 2, at: @now - 2.hours)
+    log_eggs(@household, @user, chicken, count: 1, at: @now - 1.day)
+
+    stats = DashboardStats.new(@household, now: @now)
+    assert_equal 2, stats.today_count
+  end
+
+  test "today_count returns 0 for an empty household" do
+    stats = DashboardStats.new(@household, now: @now)
+    assert_equal 0, stats.today_count
+  end
+
+  # ---- today_collections_count ----
+
+  test "today_collections_count counts collection_entries today only" do
+    chicken = make_chicken(@household, name: "Penelope")
+    log_eggs(@household, @user, chicken, count: 2, at: @now - 1.hour)
+    log_eggs(@household, @user, chicken, count: 1, at: @now - 3.hours)
+    log_eggs(@household, @user, chicken, count: 1, at: @now - 2.days)
+
+    stats = DashboardStats.new(@household, now: @now)
+    assert_equal 2, stats.today_collections_count
+  end
+
+  # ---- this_week_count + change pct + sparkline ----
+
+  test "this_week_count sums egg entries within the week (Mon-Sun)" do
+    chicken = make_chicken(@household, name: "Penelope")
+    monday = @now.beginning_of_week
+    log_eggs(@household, @user, chicken, count: 2, at: monday + 1.hour)
+    log_eggs(@household, @user, chicken, count: 1, at: @now)
+    # outside the week
+    log_eggs(@household, @user, chicken, count: 5, at: monday - 1.day)
+
+    stats = DashboardStats.new(@household, now: @now)
+    assert_equal 3, stats.this_week_count
+  end
+
+  test "this_week_change_pct returns rounded delta vs prior week" do
+    chicken = make_chicken(@household, name: "Penelope")
+    log_eggs(@household, @user, chicken, count: 2, at: @now)
+    log_eggs(@household, @user, chicken, count: 1, at: @now - 7.days)
+    # 1 -> 3 is +200%
+    stats = DashboardStats.new(@household, now: @now)
+    # this_week = 2, last_week = 1 → +100
+    assert_equal 100, stats.this_week_change_pct
+  end
+
+  test "this_week_change_pct returns nil when last week had no eggs" do
+    chicken = make_chicken(@household, name: "Penelope")
+    log_eggs(@household, @user, chicken, count: 2, at: @now)
+
+    stats = DashboardStats.new(@household, now: @now)
+    assert_nil stats.this_week_change_pct
+  end
+
+  test "this_week_sparkline_data returns daily counts keyed by ISO date" do
+    chicken = make_chicken(@household, name: "Penelope")
+    monday = @now.beginning_of_week
+    log_eggs(@household, @user, chicken, count: 2, at: monday + 1.hour)
+    log_eggs(@household, @user, chicken, count: 1, at: monday + 1.day + 2.hours)
+
+    stats = DashboardStats.new(@household, now: @now)
+    data = stats.this_week_sparkline_data
+
+    assert_equal 2, data[monday.to_date.iso8601]
+    assert_equal 1, data[(monday + 1.day).to_date.iso8601]
+  end
+
+  # ---- active_hens ----
+
+  test "active_hens_count includes pullet/layer/molting, excludes retired/expired" do
+    make_chicken(@household, name: "P", status: "pullet")
+    make_chicken(@household, name: "L", status: "layer")
+    make_chicken(@household, name: "M", status: "molting")
+    make_chicken(@household, name: "R", status: "retired")
+    make_chicken(@household, name: "E", status: "expired")
+
+    stats = DashboardStats.new(@household, now: @now)
+    assert_equal 3, stats.active_hens_count
+  end
+
+  test "active_hens_breakdown surfaces molting and retired counts only" do
+    make_chicken(@household, name: "L", status: "layer")
+    make_chicken(@household, name: "M1", status: "molting")
+    make_chicken(@household, name: "M2", status: "molting")
+    make_chicken(@household, name: "R", status: "retired")
+
+    stats = DashboardStats.new(@household, now: @now)
+    assert_equal "2 molting · 1 retired", stats.active_hens_breakdown
+  end
+
+  test "active_hens_breakdown returns empty string when nothing notable" do
+    make_chicken(@household, name: "L", status: "layer")
+    stats = DashboardStats.new(@household, now: @now)
+    assert_equal "", stats.active_hens_breakdown
+  end
+
+  # ---- best_in_flock_this_month ----
+
+  test "best_in_flock_this_month returns top hen and count this month" do
+    p = make_chicken(@household, name: "Penelope")
+    l = make_chicken(@household, name: "Louise")
+    log_eggs(@household, @user, p, count: 2, at: @now - 1.day)
+    log_eggs(@household, @user, p, count: 2, at: @now - 2.days)
+    log_eggs(@household, @user, l, count: 1, at: @now - 1.day)
+
+    stats = DashboardStats.new(@household, now: @now)
+    result = stats.best_in_flock_this_month
+
+    assert_equal p.id, result[:chicken].id
+    assert_equal 4, result[:egg_count]
+  end
+
+  test "best_in_flock_this_month returns nil when no eggs this month" do
+    stats = DashboardStats.new(@household, now: @now)
+    assert_nil stats.best_in_flock_this_month
+  end
+
+  # ---- employee_of_the_month ----
+
+  test "employee_of_the_month returns top N chickens with rank" do
+    p = make_chicken(@household, name: "Penelope")
+    l = make_chicken(@household, name: "Louise")
+    h = make_chicken(@household, name: "Henderson")
+    log_eggs(@household, @user, p, count: 2, at: @now)
+    log_eggs(@household, @user, p, count: 2, at: @now - 1.day)
+    log_eggs(@household, @user, l, count: 2, at: @now)
+    log_eggs(@household, @user, h, count: 1, at: @now)
+
+    stats = DashboardStats.new(@household, now: @now)
+    rows = stats.employee_of_the_month(limit: 3)
+
+    assert_equal 3, rows.length
+    assert_equal p.id, rows[0][:chicken].id
+    assert_equal 4, rows[0][:egg_count]
+    assert_equal 1, rows[0][:rank]
+    assert_equal 2, rows[1][:rank]
+    assert_equal 3, rows[2][:rank]
+  end
+
+  test "employee_of_the_month skips chicken_id NULL flock-mode entries" do
+    p = make_chicken(@household, name: "Penelope")
+    log_eggs(@household, @user, p, count: 2, at: @now)
+    # Flock-mode entry has chicken_id: nil. The existing EggEntry model has
+    # an unrelated bug where this fails validation; bypass via insert.
+    entry = @household.collection_entries.create!(user: @user, created_at: @now)
+    EggEntry.insert!({
+      collection_entry_id: entry.id,
+      chicken_id: nil,
+      egg_count: 5,
+      created_at: @now,
+      updated_at: @now
+    })
+
+    stats = DashboardStats.new(@household, now: @now)
+    rows = stats.employee_of_the_month
+    assert_equal 1, rows.length
+    assert_equal p.id, rows[0][:chicken].id
+  end
+
+  test "employee_of_the_month returns empty array with no eggs" do
+    stats = DashboardStats.new(@household, now: @now)
+    assert_equal [], stats.employee_of_the_month
+  end
+
+  # ---- month_calendar_data ----
+
+  test "month_calendar_data returns daily counts keyed by ISO date" do
+    chicken = make_chicken(@household, name: "Penelope")
+    log_eggs(@household, @user, chicken, count: 2, at: Time.zone.parse("2026-04-15 10:00:00 UTC"))
+    log_eggs(@household, @user, chicken, count: 1, at: Time.zone.parse("2026-04-15 14:00:00 UTC"))
+    log_eggs(@household, @user, chicken, count: 4, at: Time.zone.parse("2026-04-22 09:00:00 UTC"))
+
+    stats = DashboardStats.new(@household, now: @now)
+    data = stats.month_calendar_data(year: 2026, month: 4)
+
+    assert_equal 3, data["2026-04-15"]
+    assert_equal 4, data["2026-04-22"]
+    assert_nil data["2026-04-01"]
+  end
+
+  # ---- todays_collections ----
+
+  test "todays_collections returns today's entries newest-first" do
+    chicken = make_chicken(@household, name: "Penelope")
+    early = log_eggs(@household, @user, chicken, count: 1, at: @now - 5.hours)
+    late = log_eggs(@household, @user, chicken, count: 1, at: @now - 1.hour)
+    # Yesterday — should be excluded
+    log_eggs(@household, @user, chicken, count: 1, at: @now - 1.day)
+
+    stats = DashboardStats.new(@household, now: @now)
+    entries = stats.todays_collections.to_a
+
+    assert_equal 2, entries.length
+    assert_equal late.id, entries.first.id
+    assert_equal early.id, entries.last.id
+  end
+end

--- a/test/queries/dashboard_stats_test.rb
+++ b/test/queries/dashboard_stats_test.rb
@@ -70,6 +70,28 @@ class DashboardStatsTest < ActiveSupport::TestCase
     assert_equal 0, stats.today_count
   end
 
+  test "today_count filters by parent CE's created_at, not the egg's" do
+    # Regression guard for Issue A from the Phase 0 review: stats must be
+    # internally consistent on a single dashboard render. If a CE was
+    # created today but contains an egg whose own created_at is yesterday
+    # (possible if the egg was added later via nested_attributes_for, or
+    # if anyone backfills timestamps), the egg should still count toward
+    # today's tally because the *collection* happened today.
+    chicken = make_chicken(@household, name: "Penelope")
+    entry = @household.collection_entries.create!(user: @user, created_at: @now - 1.hour)
+    EggEntry.insert!({
+      collection_entry_id: entry.id,
+      chicken_id: chicken.id,
+      egg_count: 2,
+      created_at: @now - 2.days,  # backdated egg timestamp
+      updated_at: @now - 2.days
+    })
+
+    stats = DashboardStats.new(@household, now: @now)
+    assert_equal 2, stats.today_count
+    assert_equal 1, stats.today_collections_count
+  end
+
   # ---- today_collections_count ----
 
   test "today_collections_count counts collection_entries today only" do


### PR DESCRIPTION
## Phase 0 — Coop redesign foundations

  Lays the groundwork for the Coop visual redesign. No major user-visible feature changes; existing pages render inside
  a new Coop-branded shell, with targeted polish on the highest-traffic logged-out + logged-in interim views so they
  don't look mismatched while Phase 1+ ships.

  ### What's in here

  **Backend foundations**
  - `chickens.accent_color` and `chickens.accent_secondary` columns for the per-hen accent system used across
  leaderboards, calendar chips, avatars, and inline name links.
  - `chickens.status` is now a Rails string-backed enum: `pullet`, `layer`, `molting`, `retired`, `expired`. Existing
  `where(status: :layer)` queries continue to work; new values are available for upcoming UI without further schema
  changes. Allows `nil` to keep historical records valid.
  - `Chicken::BREED_TINTS` registry (37 breeds — 36 from the design handoff plus Production Blue) and
  `Chicken::CUSTOM_PALETTE` (12-color picker palette for the New Chicken form's custom-breed flow, used in Phase 2).
  - `before_validation :backfill_accent_from_breed` hook stamps the accent on save when the breed matches a registry
  entry. Skips when `accent_color` is already set, so the custom-color picker isn't clobbered.
  - Two backfill data migrations: one populates accents on all existing chickens whose breed matches the registry; one
  retroactively tints Production Blue chickens that pre-dated that entry being added.
  - `collection_entries#today` accepts `?date=YYYY-MM-DD` (household-local), defaulting to today. Malformed and blank
  values fall back gracefully. This is the click target for the new dashboard's calendar days in Phase 1.
  - New `DashboardStats` query object at `app/queries/dashboard_stats.rb` with methods for
  today/this-week/best-in-flock/employee-of-the-month/calendar-density/today's-collections aggregations. Scoped per
  household, time-zone-correct, no caching v1, fully tested with hand-built factory helpers (no FactoryBot).
  - `Household has_many :egg_entries, through: :collection_entries` so the query object can reach egg entries cleanly.

  **Visual foundations**
  - Coop design tokens in `app/assets/tailwind/application.css` as `@theme` properties: cream/terracotta/ink/line
  palette, status-pill foreground/background pairs, and the type stack (Caprasimo display, Nunito body, JetBrains Mono
  kicker/timestamps).
  - Reusable `@layer components` patterns: `.coop-card`, `.coop-button-primary`, `.coop-button-secondary`,
  `.coop-input`, `.coop-pill`, `.coop-kicker`, plus `.coop-status[data-status="..."]` so views just stamp the enum
  value.
  - Retired `.card` and `.link` (truly unused). Kept `.outer-container`, `.calendar-filter-selection-container`,
  `.no-calendar-info-container`, `.btn-upcase` as a deferred-cleanup block so `collection_entries#index` stays styled
  through phases 1–3; they're flagged for deletion when Phase 4 replaces that view.
  - New layout shell in `app/views/layouts/application.html.erb`: Coop top bar replacing the old blue banner, Google
  Fonts loaded with preconnects, theme color and PWA manifest linked.
  - New shared partials: `_top_bar`, `_top_bar_nav_items`, `_wordmark`, `_user_avatar`. Top bar is two-row at < md
  breakpoint so the nav can scroll horizontally without crowding the wordmark/avatar/log-out cluster.

  **PWA**
  - Manifest is now actually wired up. Previously the routes were commented out and the layout didn't reference the
  manifest; Henventory wasn't installable. Now it is.
  - Manifest theme color (`#c4622d` terracotta), background color (`#fbf5e9` cream), `short_name`, and orientation hints
   updated. Icon files still use the legacy artwork — splash screen will be Coop-branded, icon won't be until new PNGs
  land. Tracked in `FLAGS.md`.

  **Polish on logged-out + interim logged-in views**
  - `marketing/hello`, `sessions/new`, `users/new`, `passwords/new`, `passwords/edit` swapped to Coop palette + form
  patterns. Logged-out journey now feels coherent end-to-end inside the new shell.
  - `marketing/home` (the interim logged-in dashboard) and `collection_entries/today` and `_collection_entry` partial
  swapped to Coop. Fixed several layout bugs along the way (see below).

  ### Bugs fixed along the way

  - **Empty notes container rendered as a styled blank circle.** `_collection_entry.html.erb` used `if
  collection_entry.notes` which is truthy for empty strings, so entries with no notes rendered an empty `bg-blue-50
  rounded-2xl` div under a "Notes" heading. Switched to `notes.present?`.
  - **Mobile layout bleed.** `home.html.erb` and `today.html.erb` had hardcoded `w-100 md:w-150` widths that overflowed
  at 375px viewports, blowing past the layout's main padding and bleeding cards off the right edge. Replaced with a
  centered `max-width: 720px` container.
  - **"Settings" → "Setting" truncation.** Top bar's single-row layout couldn't fit wordmark + nav + avatar at narrow
  widths, so the trailing nav item silently clipped with no visible scroll indicator. At < md the nav drops to its own
  row underneath.
  - **Orphaned "got some eggs?" CTA.** Was floating mid-page because its wrapper had no centering while siblings did.
  Now sits inline within a single max-width container.

  ### Removed

  - The 200px chicken `image_tag` inline in the collection_entry partial — felt mismatched with the redesign's
  accent-swatch + initials avatar pattern. The `image_url` column still exists; long-term placement of chicken images is
   an open product call (see `FLAGS.md`).

  ### Deploy notes

  - Three new migrations run on deploy in this order:
    1. `AddAccentColorsToChickens` — schema only.
    2. `BackfillChickenAccentColors` — populates accents for all existing rows whose breed matches the registry. Inline,
   transaction-wrapped, no-op rollback. Idempotent.
    3. `BackfillProductionBlueAccents` — retroactively tints existing Production Blues that pre-dated that registry
  entry. Same shape.
  - All three are safe at the current household scale (< 1000 chickens) and will complete in seconds. No manual
  prod-console intervention needed.
  - The `before_validation` hook handles ongoing writes after deploy, so future chickens get backfilled automatically on
   save.
  - After deploy, any chicken whose breed string doesn't exactly match a registry entry (case-insensitive, trimmed)
  keeps `accent_color: nil`. Examples in dev: a `"Leghorn"` (registry has `"Leghorn (White)"` and `"Leghorn (Brown)"` —
  no plain `"Leghorn"`). These get assigned via the New Chicken custom-color picker once Phase 2 ships.

  ### What this PR does NOT do (intentionally)

  - Doesn't ship the redesigned dashboard. That's Phase 1 — Layer-mode dashboard with greeting + Quick-Log + stat strip
  + monthly calendar + leaderboard + Today's collections strip. The interim `marketing/home` is polished but gets fully
  replaced.
  - Doesn't ship the New Chicken form rebuild. That's Phase 2 — fuse.js fuzzy breed type-ahead, custom-color picker,
  live preview.
  - Doesn't ship Flock-mode dashboard or weather integration. Phase 3.
  - Doesn't redesign `faq`, `how_it_works`, `acknowledgements`, or `users/edit`. They stay blue inside the Coop shell —
  visual mismatch is intentional and tracked in `FLAGS.md`. They get proper redesigns in Phase 4 (marketing surfaces +
  settings).
  - Doesn't fix the pre-existing test suite baseline (10 failures + 11 errors on `main`, all auth-redirect issues in
  controller tests). Same baseline on this branch — zero new failures introduced. Worth a dedicated PR before Phase 1
  system tests start landing.

  ### Test plan

  - [ ] `bin/rails test` — confirm same 10/11 pre-existing baseline, no new failures.
  - [ ] Migrations run forward + roll back cleanly in dev.
  - [ ] After deploy, verify all existing Production Blue chickens have `accent_color: "#7a7a85"`.
  - [ ] Spot-check existing chickens whose breeds don't match the registry — they should be `nil` accent (not erroring).
  - [ ] Logged-out journey: visit `/`, click sign up, click log in, click forgot password — all five views should render
   in the Coop shell with no blue/lime leakage.
  - [ ] Logged-in: hit `/home` and `/collection_entries/today` at 375px and 1280px viewports — content should fit inside
   the viewport, "got some eggs?" should sit inline with surrounding cards, top bar nav should drop to a second row at
  narrow widths.
  - [ ] Verify "Add to Home Screen" on iOS Safari and Android Chrome — splash screen should be cream with terracotta
  theme color (icon will still be legacy until new artwork lands).
  
  
 ### Preview
 ## Before
<img width="1919" height="928" alt="Screenshot 2026-05-01 132119" src="https://github.com/user-attachments/assets/abe1eeeb-af9a-4dad-95b7-a6fdb9002f95" /><br/>

<img width="1916" height="928" alt="Screenshot 2026-05-01 132136" src="https://github.com/user-attachments/assets/c43f5079-5bb6-4bf7-bf28-797c2c120579" />

## After
<img width="969" height="923" alt="Screenshot 2026-05-07 143339" src="https://github.com/user-attachments/assets/5dc456b9-e18b-4912-81a2-336648574cce" /><br/>

<img width="970" height="926" alt="Screenshot 2026-05-07 143436" src="https://github.com/user-attachments/assets/9beed4d6-0212-48b0-bfd8-351c4d20a5b6" />

________________________
🤖 Generated with Claude Code (https://claude.com/claude-code)

  Co-Authored-By: Claude Opus 4.7 noreply@anthropic.com