### PR TITLE
Fix edit-form timepicker rendering an unparseable default

### DIFF
--- a/app/views/collection_entries/_form_container.html.erb
+++ b/app/views/collection_entries/_form_container.html.erb
@@ -19,6 +19,7 @@
             class: '' %>
       </div>
         <%= collection_entry_form.text_field :collected_at,
+            value: @collection_entry.collected_at&.in_time_zone(@local_time_zone)&.strftime("%I:%M %p"),
             data: {
               controller: "flatpickr",
               flatpickr_enable_time: true,


### PR DESCRIPTION
## Context

Hotfix for a production bug discovered after PR #169 deployed. The slow-path `/collection_entries/edit` form's flatpickr timepicker was rendering a garbage default value (~8:06 PM, deterministic per record) instead of the entry's actual `collected_at` time. Users editing an entry without manually re-picking the time would then save 8:06 PM as the new `collected_at` — silently corrupting roughly a few dozen production rows over the lifetime of the bug.

PR #169 (data-layer hardening) is a precondition for this fix being meaningful: now that `collected_at` is parsed in the household's timezone on submit, fixing what the picker pre-fills on edit closes the last link in the chain.

## Root cause

Rails' `text_field` helper renders the model attribute via `.to_s`. On a `TimeWithZone`, that produces a string like `"2026-05-14 13:45:00 UTC"`.

flatpickr is configured with `date_format: "h:i K"` (12-hour time only, e.g. `"08:45 AM"`) and cannot parse the Rails-stringified Time. It falls back to its lenient `parseDate`, which interprets the leading date numerals as time arithmetic and lands deterministically near 8:06 PM. The garbage value is then written into the hidden input and submitted; `#update`'s parse logic happily converts that to a Time and saves it.

The `flatpickr_default_hour: 8` config is a red herring — it only applies when the input is *empty*. On `#edit` the input has a value, just an unparseable one, so the default never fires.

## Fix

One-line change in `app/views/collection_entries/_form_container.html.erb`: explicitly pre-format `collected_at` into a string flatpickr can parse, via the `value:` option on `text_field`.

```erb
value: @collection_entry.collected_at&.in_time_zone(@local_time_zone)&.strftime("%I:%M %p"),
```

The safe-navigation chain (`&.`) handles both code paths:
- **`#new`**: `collected_at` is nil → the chain short-circuits to nil → field renders empty → `flatpickr_default_hour: 8` kicks in as intended (picker shows 8:00 AM default). No behavior change from before.
- **`#edit`**: `collected_at` is a real Time → converted to Central → formatted as `"08:45 AM"` → flatpickr parses cleanly → picker displays the entry's actual saved time.

## Why not fix `flatpickr_controller.js` instead

The Stimulus controller is just a thin wrapper around stimulus-flatpickr. The issue isn't that the JS is misbehaving — it's that the field's `value=` attribute (which Rails populates) is in a format flatpickr can't understand. Fixing it at the view layer means the JS sees a parseable value and Just Works. Fixing it in JS would require a custom `parseDate` hook duplicating what `.strftime("%I:%M %p")` already does at the view layer. The view fix is smaller, more local, and easier to reason about.

## Test plan

- [x] Local: `#edit` displays the entry's real `collected_at` (not 8:06 PM)
- [x] Local: re-saving an edit without changing the time preserves the value
- [x] Local: re-saving with a changed time persists the new value correctly
- [x] Local: `#new` still defaults to 8:00 AM (`flatpickr_default_hour` continues to fire on empty input)
- [ ] Prod: spot-check on a freshly-edited entry post-deploy
- [ ] Prod: identify and correct the few dozen entries corrupted by this bug pre-fix (separate follow-up — see "Out of scope")

## Out of scope

- **Backfilling the corrupted entries.** A few dozen entries in prod were saved with the 8:06 PM (or whatever flatpickr's garbage value was for that record) value via the edit form. They need a separate, narrower correction pass — likely a shell script similar to the one used for the pre-#169 UTC-shift correction, but identifying rows where `collected_at` is suspiciously near 8:06 PM Central and `updated_at > created_at` (i.e., the entry was edited, which is the only path that triggered this bug). Filed as a follow-up.
- **Quick-Log entries are unaffected.** Quick-Log doesn't use this form; it auto-fills `Time.current` server-side per PR #169.
