### PR TITLE
Add NOT NULL constraint to collection_entries.collected_at

### DIFF
--- a/db/migrate/20260515160948_add_not_null_to_collection_entries_collected_at.rb
+++ b/db/migrate/20260515160948_add_not_null_to_collection_entries_collected_at.rb
@@ -1,0 +1,5 @@
+class AddNotNullToCollectionEntriesCollectedAt < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :collection_entries, :collected_at, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_08_190113) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_15_160948) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -35,7 +35,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_08_190113) do
     t.datetime "updated_at", null: false
     t.integer "household_id"
     t.text "notes"
-    t.datetime "collected_at"
+    t.datetime "collected_at", null: false
     t.index ["collected_at"], name: "index_collection_entries_on_collected_at"
     t.index ["household_id", "created_at"], name: "index_collection_entries_on_household_id_and_created_at"
   end


### PR DESCRIPTION
## Context

Final piece of the `collected_at` rollout that began with PR #169. The model has been enforcing presence since #169 shipped (`validates :collected_at, presence: true`); this PR moves that guarantee down to the database level via a `NOT NULL` constraint.

Originally this was tracked as "Phase 3" of the timepicker rollout (Phase 1 = data layer in #169, Phase 2 = production backfill, Phase 3 = NOT NULL). The backfill work turned out to span two separate corrections — see "Preconditions" below.

## What this PR does

One migration: `change_column_null :collection_entries, :collected_at, false`.

Postgres validates the constraint against every existing row at migration time. With the preconditions met (zero nil rows in prod, Quick-Log auto-fill preventing new nils), that validation is a no-op pass.

`change_column_null` is preferable to a full column redefinition here because it doesn't touch the existing index on `collected_at` or the indexes on `(household_id, created_at)`.

## Preconditions (already met before this PR opens)

1. **Pre-#169 UTC-shift correction** — completed 2026-05-14 via shell-pasted script. Affected ~1,040 rows where the user's intended local time was stored as if it were UTC during the pre-#169 bug window (2025-11-13 → 2026-05-14). Script shifted each row forward by its household's UTC offset at the row's `created_at` instant, DST-aware (789 rows by 5h for CDT, 251 rows by 6h for CST). Audit trail commented on PR #169.

2. **Nil-to-`created_at` backfill** — completed 2026-05-15 via shell-pasted script. Affected 126 rows where `collected_at IS NULL`, predominantly Quick-Log Layer entries from the window between PR #167 (Quick-Log shipped without `collected_at`) and PR #169 (auto-fill landed). Backfilled each row's `collected_at` to its `created_at` — correct by intent for Quick-Log ("log now" means `created_at`), honest best-guess for any other path. Audit trail will be commented on PR #169.

3. **Verified zero nil rows immediately before this PR opens.**
   `CollectionEntry.where(collected_at: nil).count == 0` in prod.

4. **Verified Quick-Log auto-fill is preventing new nils.** PR #169's `@collection_entry.collected_at ||= Time.current if params[:quick_log].present?` line ensures no new nil rows appear between now and this migration deploying.

## Why two separate backfills

These were independent bugs surfaced by different paths:

- The UTC-shift was a parsing bug — `Time.zone.parse(...)` ran with Rails' default UTC zone instead of the household zone, storing the user's typed local time as if it were UTC.
- The nil rows came from Quick-Log not submitting the field at all during a window when the model didn't require it.

Both had to be cleaned up before NOT NULL could be safely applied, but they were not related operations and used different fix strategies.

## Test plan

- [x] Migration runs cleanly locally
- [x] Schema updated to `t.datetime "collected_at", null: false`
- [x] Scoped test suite green (60 runs, 166 assertions): models, queries, collection_entries controller, dashboards controller
- [ ] Migration deploys cleanly to staging
- [ ] Migration deploys cleanly to prod
- [ ] Post-deploy: `CollectionEntry.where(collected_at: nil).count` still returns 0 (sanity check)
- [ ] Post-deploy: a fresh Quick-Log submission and a fresh slow-path submission both work end-to-end

## Out of scope / closing notes

- This closes the `collected_at` rollout. No further phases planned.
- Rebrand Phase 2 is the next major workstream and is entirely independent of this change.
- The shell-pasted backfill scripts and their audit logs are kept private in local notes (not committed). They are referenced from PR #169 comments for posterity.
